### PR TITLE
Added CHIME synthetic dataset and BERT fine-tuning experiment

### DIFF
--- a/ml_experiments_ayusrjn/README.md
+++ b/ml_experiments_ayusrjn/README.md
@@ -1,0 +1,42 @@
+# ML Experiments - DREAMS
+
+## Project Overview
+This folder contains machine learning experiments for classifying user recovery journeys based on text captions uploaded to the Beehive platform. The project is built on the CHIME Personal Recovery Framework and uses synthetic datasets for model training and evaluation.
+
+## Objective
+- **Primary Goal**: Classify user recovery journey stages from text captions
+- **Future Expansion**: Extend classification to include image analysis
+- **Framework**: CHIME Personal Recovery Framework
+- **Platform**: Beehive platform integration
+
+## Dataset
+- **Type**: Synthetic dataset based on CHIME framework
+- **Content**:Trying to stimulate user-generated captions from recovery journey posts
+- **Size**: Currently 505 Unique Entries Expanding
+- **Classes**: Connectedness, Hope, Identity, Meaning, Empowerment
+- **Link**: [HuggingFace](https://huggingface.co/datasets/ayusrjn/CHIME-recovery-framework)
+
+
+## Experiments Status
+
+### Experiment Log
+
+| Experiment ID | Model | Status | Best Accuracy | Best F1 | Notes |
+|---------------|-------|--------|---------------|---------|-------|
+| EXP-001 | [bert-base-uncased] | In Progress | 0.8431 | 0.8416544 | badly overfitted |
+| EXP-002 | [Model Name] | Planned | - | - | - |
+| EXP-003 | [Model Name] | Planned | - | - | - |
+
+## Current Model
+[HuggingFace Hub](https://huggingface.co/ayusrjn/bert-finetuned-on-chime/tree/main)
+
+
+## Notes
+- This experiment focuses on text-based classification from captions
+- Future work will expand to multimodal (text + image) analysis
+- All experiments use synthetic data based on CHIME framework principles
+- Results will be benchmarked against implementation approach
+
+
+---
+*Last Updated: [05/06/2025]*

--- a/ml_experiments_ayusrjn/experiment1/BERT-Finetunning.ipynb
+++ b/ml_experiments_ayusrjn/experiment1/BERT-Finetunning.ipynb
@@ -1,0 +1,1295 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Ad6rq6thX-jU"
+      },
+      "source": [
+        "# Fine-Tunning BERT for CHIME Framework DREAMS\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "h4dXENhnYJU0"
+      },
+      "source": [
+        "Installing Compatible packages"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 983
+        },
+        "collapsed": true,
+        "id": "T1e1c_LAHN4N",
+        "outputId": "f484e50d-c2f3-4ddc-a9c6-19ab50de3189"
+      },
+      "outputs": [],
+      "source": [
+        "!pip uninstall -y numpy datasets\n",
+        "!pip install numpy==1.26.4 datasets --no-cache-dir\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 15,
+      "metadata": {
+        "id": "7ChFQavgCpMH"
+      },
+      "outputs": [],
+      "source": [
+        "import pandas as pd\n",
+        "from transformers import BertTokenizerFast, BertForSequenceClassification, Trainer, TrainingArguments\n",
+        "from sklearn.model_selection import train_test_split\n",
+        "import torch\n",
+        "from datasets import Dataset"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "9IykOamhYOtI"
+      },
+      "source": [
+        "## Reading the Dataset"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 69,
+      "metadata": {
+        "id": "PVLHFnVNCu6L"
+      },
+      "outputs": [],
+      "source": [
+        "df  = pd.read_csv(\"/content/dataset.csv\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 70,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 272
+        },
+        "id": "5xvvpplEDOUw",
+        "outputId": "a4a3a353-bb95-454b-8531-f657a7533ec8"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>count</th>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>labels</th>\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>Meaning</th>\n",
+              "      <td>112</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>Empowerment</th>\n",
+              "      <td>109</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>Identity</th>\n",
+              "      <td>106</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>Hope</th>\n",
+              "      <td>98</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>Connectedness</th>\n",
+              "      <td>79</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div><br><label><b>dtype:</b> int64</label>"
+            ],
+            "text/plain": [
+              "labels\n",
+              "Meaning          112\n",
+              "Empowerment      109\n",
+              "Identity         106\n",
+              "Hope              98\n",
+              "Connectedness     79\n",
+              "Name: count, dtype: int64"
+            ]
+          },
+          "execution_count": 70,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "df['labels'].value_counts()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "xY1_r_P_YUmj"
+      },
+      "source": [
+        "## Train Test Split"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 71,
+      "metadata": {
+        "id": "BtTrd8BvDQOh"
+      },
+      "outputs": [],
+      "source": [
+        "train_df, val_df = train_test_split(df, test_size=0.1, stratify=df['labels'])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "9JjVfkrDYZ4m"
+      },
+      "source": [
+        "### Exporting the Dataset from Pandas To Hugging Face Dataset"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 72,
+      "metadata": {
+        "id": "ZC5P3EdFDkBD"
+      },
+      "outputs": [],
+      "source": [
+        "train_dataset = Dataset.from_pandas(train_df.reset_index(drop=True))\n",
+        "val_dataset = Dataset.from_pandas(val_df.reset_index(drop=True))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "1mTNxM-nYi3j"
+      },
+      "source": [
+        "## Model Selection\n",
+        "### In this case we have selected the bert-base-uncased model from google with the hugging face transformers model for the tokenizer"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 73,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "R_9Swc4HD3SM",
+        "outputId": "60e8efd3-b165-46e8-a98b-a7f653966239"
+      },
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Some weights of BertForSequenceClassification were not initialized from the model checkpoint at bert-base-uncased and are newly initialized: ['classifier.bias', 'classifier.weight']\n",
+            "You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference.\n"
+          ]
+        }
+      ],
+      "source": [
+        "model_name = \"bert-base-uncased\"\n",
+        "tokenizer = BertTokenizerFast.from_pretrained(model_name)\n",
+        "model = BertForSequenceClassification.from_pretrained(model_name, num_labels=len(df['labels'].unique()))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "collapsed": true,
+        "id": "Sd1LU4fZMSSZ",
+        "outputId": "b20ba7ab-eeed-460e-c73c-805e2bb45053"
+      },
+      "outputs": [],
+      "source": [
+        "print(train_dataset[0])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "K0fkuuchY656"
+      },
+      "source": [
+        "### Defining the Tokenizer Function\n",
+        "We have the labels column in text forms but the model needs them to be in numerical format so we need to convert those"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 136,
+          "referenced_widgets": [
+            "f1f109d1719e4d89b791576e070d3edd",
+            "308a25e0053d4a7a9bba9c3f521b72fd",
+            "c80357f710474695938fcd62d6a7aab0",
+            "77ee5785ba7840d28a02717e4a3a9530",
+            "7f4c92c6925a426995a83deffd387dcb",
+            "37185fed763042a69d7f809489642f42",
+            "d67b76502e3746c58969304aef7121dc",
+            "41951a1181924f10b344297fd438aaeb",
+            "04c47ce7c4404b419a32814f7b498a26",
+            "179c95e997914c39a03ea7869ac4544c",
+            "ff9804f98010416db1edb5dcfcd57c43",
+            "4c97f76ee10246f69c23f5f0137b66f6",
+            "5531d72dd26e4967bd145cbe002202d7",
+            "85c2b5dd7de24a4294112e0e876e1422",
+            "499f7020e59a4c21bdbc5228c9981062",
+            "bddd74b4fa4841638c73f7bbb2a21f15",
+            "78363259d2164c8ebe8bb18ad4032780",
+            "3392a39426af4fcca13cdf4ff09e2a8b",
+            "1ae87231917d4b98be8120a647c2ef2c",
+            "43d0e5a1fc974e1e8531fb7a14e1ec07",
+            "bc6829d9463b4268836a7ea76e382199",
+            "e45afed9b836464a8efe5c0b178c36f5"
+          ]
+        },
+        "collapsed": true,
+        "id": "h5YV_H5NEO7W",
+        "outputId": "e704ec02-53ac-4ff4-e59a-2e4ef647cf8a"
+      },
+      "outputs": [],
+      "source": [
+        "def tokenize_function(examples):\n",
+        "  tokenized_inputs = tokenizer(examples['CAPTIONS'], padding='max_length', truncation=True, max_length=128)\n",
+        "  label_map = {label: i for i, label in enumerate(unique_labels)}\n",
+        "  tokenized_inputs['labels'] = [label_map[label] for label in examples['labels']]\n",
+        "  return tokenized_inputs\n",
+        "\n",
+        "unique_labels = df['labels'].unique().tolist()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "tMTBbkNrZgT0"
+      },
+      "source": [
+        "#### Mapping the Dataset to the Tokenizer Function"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "AOzsEY6PZfY6"
+      },
+      "outputs": [],
+      "source": [
+        "train_dataset = train_dataset.map(tokenize_function, batched=True, remove_columns=[\"CAPTIONS\"])\n",
+        "val_dataset = val_dataset.map(tokenize_function, batched=True, remove_columns=[\"CAPTIONS\"])\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "5uY5GrvTZne4"
+      },
+      "source": [
+        "#### Setting the Format for the Model\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "NwVGv2UGZmqF"
+      },
+      "outputs": [],
+      "source": [
+        "train_dataset.set_format(type='torch', columns=['input_ids', 'attention_mask', 'labels'])\n",
+        "val_dataset.set_format(type='torch', columns=['input_ids', 'attention_mask', 'labels'])\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "S6n5ueSXZ8tR"
+      },
+      "source": [
+        "### Defining the Trainer Parameters"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "MLMLWtQHZwp5"
+      },
+      "outputs": [],
+      "source": [
+        "model = BertForSequenceClassification.from_pretrained(model_name, num_labels=len(unique_labels))\n",
+        "\n",
+        "# Re-initialize the trainer with the updated model and datasets\n",
+        "trainer = Trainer(\n",
+        "    model=model,\n",
+        "    args=training_args,\n",
+        "    train_dataset=train_dataset,\n",
+        "    eval_dataset=val_dataset,\n",
+        "    compute_metrics=compute_metrics,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "elywwo0gaFiK"
+      },
+      "source": [
+        "Importing the Evaluation Metrics"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 75,
+      "metadata": {
+        "id": "t46RrNVhFPth"
+      },
+      "outputs": [],
+      "source": [
+        "from sklearn.metrics import accuracy_score, precision_recall_fscore_support\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 76,
+      "metadata": {
+        "id": "Elm-WHLEFbiw"
+      },
+      "outputs": [],
+      "source": [
+        "def compute_metrics(eval_pred):\n",
+        "    logits, labels = eval_pred\n",
+        "    preds = logits.argmax(axis=1)\n",
+        "    precision, recall, f1, _ = precision_recall_fscore_support(labels, preds, average='weighted')\n",
+        "    acc = accuracy_score(labels, preds)\n",
+        "    return {\"accuracy\": acc, \"f1\": f1, \"precision\": precision, \"recall\": recall}\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "-h2ZXLuFaSWW"
+      },
+      "source": [
+        "## Fine Tunning the Model"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 378
+        },
+        "collapsed": true,
+        "id": "u3GCuCbJFf4U",
+        "outputId": "6559dae5-797a-4978-8e8d-b9a8b94151c8"
+      },
+      "outputs": [],
+      "source": [
+        "trainer = Trainer(\n",
+        "    model=model,\n",
+        "    args=training_args,\n",
+        "    train_dataset=train_dataset,\n",
+        "    eval_dataset=val_dataset,\n",
+        "    compute_metrics=compute_metrics,\n",
+        ")\n",
+        "\n",
+        "\n",
+        "trainer.train()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "2gBVD6EEbA21"
+      },
+      "source": [
+        "| Step | Training Loss |\n",
+        "|------|---------------|\n",
+        "| 10   | 1.588700      |\n",
+        "| 20   | 1.418100      |\n",
+        "| 30   | 1.310200      |\n",
+        "| 40   | 1.106600      |\n",
+        "| 50   | 0.910300      |\n",
+        "| 60   | 0.744400      |\n",
+        "| 70   | 0.632500      |\n",
+        "| 80   | 0.583700      |\n",
+        "\n",
+        "\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "er12JkZdbXhj"
+      },
+      "source": [
+        "TrainOutput(global_step=87, training_loss=0.9958692802779976, metrics={'train_runtime': 1815.2712, 'train_samples_per_second': 0.749, 'train_steps_per_second': 0.048, 'total_flos': 89394388902144.0, 'train_loss': 0.9958692802779976, 'epoch': 3.0})"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "DWPyhRQbaZmc"
+      },
+      "source": [
+        "## Evaluating on Evaluation Set\n",
+        "{'eval_loss': 0.6967468857765198, 'eval_accuracy': 0.8431372549019608, 'eval_f1': 0.8416544596031978, 'eval_precision': 0.8469498910675383, 'eval_recall': 0.8431372549019608, 'eval_runtime': 30.1742, 'eval_samples_per_second': 1.69, 'eval_steps_per_second': 0.133, 'epoch': 3.0}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 74
+        },
+        "collapsed": true,
+        "id": "HtbuRAydGlOB",
+        "outputId": "082c44c7-2aeb-46fb-9eec-baad09e376ce"
+      },
+      "outputs": [],
+      "source": [
+        "eval_results = trainer.evaluate()\n",
+        "print(eval_results)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "MIjKkpU4arM9"
+      },
+      "source": [
+        "### Testing custom captions"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 94,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "WPaw9e2VT4k1",
+        "outputId": "a9bd8a8d-8763-4dba-b6b8-7ba272f0f104"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "The predicted label for the custom text is: Empowerment\n"
+          ]
+        }
+      ],
+      "source": [
+        "custom_text = \"I am not my past but i am my future\"\n",
+        "\n",
+        "tokenized_input = tokenizer(custom_text, padding='max_length', truncation=True, max_length=128, return_tensors=\"pt\")\n",
+        "\n",
+        "with torch.no_grad():\n",
+        "    outputs = model(**tokenized_input)\n",
+        "    logits = outputs.logits\n",
+        "\n",
+        "predicted_class_index = torch.argmax(logits, dim=1).item()\n",
+        "\n",
+        "predicted_label = unique_labels[predicted_class_index]\n",
+        "\n",
+        "print(f\"The predicted label for the custom text is: {predicted_label}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "HOh3wIzCa0Oy"
+      },
+      "source": [
+        "Exporting my model for future reference"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 95,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "LIl3ek4vUrtp",
+        "outputId": "5720f5d9-073d-4e25-f94a-82e18a11b87a"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Model and tokenizer saved to ./my_bert_model\n"
+          ]
+        }
+      ],
+      "source": [
+        "output_dir = \"./my_bert_model\"\n",
+        "\n",
+        "model.save_pretrained(output_dir)\n",
+        "\n",
+        "tokenizer.save_pretrained(output_dir)\n",
+        "\n",
+        "print(f\"Model and tokenizer saved to {output_dir}\")"
+      ]
+    }
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "widgets": {
+      "application/vnd.jupyter.widget-state+json": {
+        "04c47ce7c4404b419a32814f7b498a26": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "ProgressStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "179c95e997914c39a03ea7869ac4544c": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "1ae87231917d4b98be8120a647c2ef2c": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "308a25e0053d4a7a9bba9c3f521b72fd": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "HTMLModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_37185fed763042a69d7f809489642f42",
+            "placeholder": "​",
+            "style": "IPY_MODEL_d67b76502e3746c58969304aef7121dc",
+            "value": "Map: 100%"
+          }
+        },
+        "3392a39426af4fcca13cdf4ff09e2a8b": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "DescriptionStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "37185fed763042a69d7f809489642f42": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "41951a1181924f10b344297fd438aaeb": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "43d0e5a1fc974e1e8531fb7a14e1ec07": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "ProgressStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "499f7020e59a4c21bdbc5228c9981062": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "HTMLModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_bc6829d9463b4268836a7ea76e382199",
+            "placeholder": "​",
+            "style": "IPY_MODEL_e45afed9b836464a8efe5c0b178c36f5",
+            "value": " 51/51 [00:00&lt;00:00, 1455.12 examples/s]"
+          }
+        },
+        "4c97f76ee10246f69c23f5f0137b66f6": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "HBoxModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_5531d72dd26e4967bd145cbe002202d7",
+              "IPY_MODEL_85c2b5dd7de24a4294112e0e876e1422",
+              "IPY_MODEL_499f7020e59a4c21bdbc5228c9981062"
+            ],
+            "layout": "IPY_MODEL_bddd74b4fa4841638c73f7bbb2a21f15"
+          }
+        },
+        "5531d72dd26e4967bd145cbe002202d7": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "HTMLModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_78363259d2164c8ebe8bb18ad4032780",
+            "placeholder": "​",
+            "style": "IPY_MODEL_3392a39426af4fcca13cdf4ff09e2a8b",
+            "value": "Map: 100%"
+          }
+        },
+        "77ee5785ba7840d28a02717e4a3a9530": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "HTMLModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_179c95e997914c39a03ea7869ac4544c",
+            "placeholder": "​",
+            "style": "IPY_MODEL_ff9804f98010416db1edb5dcfcd57c43",
+            "value": " 453/453 [00:00&lt;00:00, 4495.02 examples/s]"
+          }
+        },
+        "78363259d2164c8ebe8bb18ad4032780": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "7f4c92c6925a426995a83deffd387dcb": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "85c2b5dd7de24a4294112e0e876e1422": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "FloatProgressModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_1ae87231917d4b98be8120a647c2ef2c",
+            "max": 51,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_43d0e5a1fc974e1e8531fb7a14e1ec07",
+            "value": 51
+          }
+        },
+        "bc6829d9463b4268836a7ea76e382199": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "bddd74b4fa4841638c73f7bbb2a21f15": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "c80357f710474695938fcd62d6a7aab0": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "FloatProgressModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_41951a1181924f10b344297fd438aaeb",
+            "max": 453,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_04c47ce7c4404b419a32814f7b498a26",
+            "value": 453
+          }
+        },
+        "d67b76502e3746c58969304aef7121dc": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "DescriptionStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "e45afed9b836464a8efe5c0b178c36f5": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "DescriptionStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "f1f109d1719e4d89b791576e070d3edd": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "HBoxModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_308a25e0053d4a7a9bba9c3f521b72fd",
+              "IPY_MODEL_c80357f710474695938fcd62d6a7aab0",
+              "IPY_MODEL_77ee5785ba7840d28a02717e4a3a9530"
+            ],
+            "layout": "IPY_MODEL_7f4c92c6925a426995a83deffd387dcb"
+          }
+        },
+        "ff9804f98010416db1edb5dcfcd57c43": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "DescriptionStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        }
+      }
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}


### PR DESCRIPTION
Added a small synthetic dataset based on the [CHIME personal recovery framework](https://pubmed.ncbi.nlm.nih.gov/22130746/) (Connectedness, Hope, Identity, Meaning, Empowerment).
Got the idea form this [paper](https://ris.utwente.nl/ws/portalfiles/portal/251381888/Vansteenkiste_2020_Images_of_recovery_a_photovoice_stu.pdf)

Tried fine-tuning a BERT model on this dataset — the model overfitted and didn’t generalize well.

Included the training notebook in the commit.

Uploaded both the dataset and the model to Hugging Face for reference:

Dataset: [HF dataset link](https://huggingface.co/datasets/ayusrjn/CHIME-recovery-framework)

Model: [HF model link](https://huggingface.co/ayusrjn/bert-finetuned-on-chime/)

This is an early experiment to test out CHIME-based classification. Will need better data and training strategy going forward.