### PR TITLE
Added sentiment trend visualization feature and base HTML structure

### DIFF
--- a/dreamsApp/app/__init__.py
+++ b/dreamsApp/app/__init__.py
@@ -34,4 +34,7 @@ def create_app(test_config=None):
     from .ingestion.routes import bp as ingestion_bp
     app.register_blueprint(ingestion_bp)
 
+    from .dashboard import bp as dashboard_bp
+    app.register_blueprint(dashboard_bp)
+
     return app

--- a/dreamsApp/app/dashboard/__init__.py
+++ b/dreamsApp/app/dashboard/__init__.py
@@ -1,0 +1,6 @@
+from flask import Blueprint
+
+bp = Blueprint('dashboard', __name__, url_prefix='/dashboard')
+
+from . import main
+

--- a/dreamsApp/app/dashboard/main.py
+++ b/dreamsApp/app/dashboard/main.py
@@ -1,9 +1,58 @@
 from flask import render_template, request
 from flask import current_app
 from . import bp
-
+import matplotlib.pyplot as plt
+import pandas as pd
+import numpy as np
+import io
+import base64
 
 @bp.route('/', methods =['GET'])
 def index():
-    return render_template('dashboard/dashboard.html')
+    mongo = current_app.mongo['posts']
+    
+
+    target_user_id = "111"
+    user_posts = list(
+    mongo.find({'user_id': target_user_id}).sort('timestamp', 1)
+    )
+
+    for post in user_posts:
+        post['sentiment_label'] = post['sentiment']['label']
+        post['sentiment_score'] = post['sentiment']['score']
+
+    df = pd.DataFrame(user_posts)
+    df['timestamp'] = pd.to_datetime(df['timestamp'])
+
+    sentiment_map = {
+        "positive": 1,
+        "neutral": 0,
+        "negative": -1
+    }
+    df['score'] = df['sentiment_label'].map(sentiment_map)
+
+    df = df.sort_values("timestamp")
+    df["cumulative_score"] = df["score"].cumsum()
+    df["rolling_avg"] = df["score"].rolling(window=5, min_periods=1).mean()
+    df["ema_score"] = df["score"].ewm(span=5, adjust=False).mean()
+
+    plt.figure(figsize=(12, 6))
+    plt.plot(df["timestamp"], df["cumulative_score"], label="Cumulative Sentiment", color="blue", marker="o", alpha=0.5)
+    plt.plot(df["timestamp"], df["rolling_avg"], label="Rolling Avg (5 days)", color="orange", linestyle="--", marker="x")
+    plt.plot(df["timestamp"], df["ema_score"], label="EMA (span=5)", color="green", linestyle="-", marker="s")
+    plt.axhline(0, color="gray", linestyle="--", linewidth=1)
+    plt.title(f"Sentiment Trend for User {target_user_id}")
+    plt.xlabel("Date")
+    plt.ylabel("Sentiment Score")
+    plt.legend()
+    plt.grid(True)
+    plt.xticks(rotation=45)
+    plt.tight_layout()
+
+    buf = io.BytesIO()
+    plt.savefig(buf, format='png')
+    buf.seek(0)
+    plot_data = base64.b64encode(buf.read()).decode('utf-8')
+    buf.close()
+    return render_template('dashboard/dashboard.html', plot_url=plot_data)
 

--- a/dreamsApp/app/dashboard/main.py
+++ b/dreamsApp/app/dashboard/main.py
@@ -1,0 +1,9 @@
+from flask import render_template, request
+from flask import current_app
+from . import bp
+
+
+@bp.route('/', methods =['GET'])
+def index():
+    return render_template('dashboard/dashboard.html')
+

--- a/dreamsApp/app/templates/base.html
+++ b/dreamsApp/app/templates/base.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Bootstrap demo</title>
+    <title>DREAMS</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-LN+7fdVzj6u52u30Kp6M/trliBMCMKTyK833zpbD+pXdCLuTusPj697FH4R/5mcr" crossorigin="anonymous">
   </head>
   <body>

--- a/dreamsApp/app/templates/base.html
+++ b/dreamsApp/app/templates/base.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Bootstrap demo</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-LN+7fdVzj6u52u30Kp6M/trliBMCMKTyK833zpbD+pXdCLuTusPj697FH4R/5mcr" crossorigin="anonymous">
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+        <div class="container-fluid">
+          <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+          </button>
+          <a class="navbar-brand position-absolute start-50 translate-middle-x fs-2" href="#">DREAMS</a>
+          <div class="collapse navbar-collapse justify-content-end" id="navbarNavAltMarkup">
+            <div class="navbar-nav">
+              <a class="nav-link active" aria-current="page" href="#">Home</a>
+              <a class="nav-link" href="#">Features</a>
+              <a class="nav-link" href="#">Pricing</a>
+              <a class="nav-link disabled" aria-disabled="true">Disabled</a>
+            </div>
+          </div>
+        </div>
+      </nav>
+    {% block content %}
+    {% endblock content %}
+    
+    <footer class="bg-dark text-light py-4 mt-5">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-4">
+                    <h5>DREAMS</h5>
+                    <p class="small">We help tell recovery stories through photos, captions, and AI-driven emotion tracking.</p>
+                </div>
+                <div class="col-md-4">
+                    <h5>Quick Links</h5>
+                    <ul class="list-unstyled">
+                        <li><a href="https://github.com/KathiraveluLab/DREAMS" class="text-light text-decoration-none">Github</a></li>
+                        <li><a href="#" class="text-light text-decoration-none">Contact</a></li>
+                        <li><a href="#" class="text-light text-decoration-none">Privacy Policy</a></li>
+                    </ul>
+                </div>
+                <div class="col-md-4">
+                    <h5>Contact</h5>
+                    <p class="small">Email: notdecided@gmail.com<br>Phone: (123) 456-7890</p>
+                </div>
+            </div>
+            <hr class="mt-4">
+            <div class="text-center small">
+                <p>&copy; 2025 DREAMS. All rights reserved.</p>
+            </div>
+        </div>
+    </footer>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js" integrity="sha384-ndDqU0Gzau9qJ1lfW4pNLlhNTkCfHzAVBReH9diLvGRem5+R9g2FzA8ZGN954O5Q" crossorigin="anonymous"></script>
+  </body>
+</html>
+
+
+

--- a/dreamsApp/app/templates/dashboard/dashboard.html
+++ b/dreamsApp/app/templates/dashboard/dashboard.html
@@ -1,0 +1,22 @@
+
+{% extends 'base.html' %}
+{% block content %}
+    <body> 
+        <div class="container">
+            <h1>Welcome to Your Dashboard</h1>
+            <p>Here you can manage your dreams and view your progress.</p>
+            <div class="dreams-list">
+                <h2>Your Dreams</h2>
+                <!-- Placeholder for dreams list -->
+                <ul id="dreamsList">
+                    <!-- Dreams will be dynamically inserted here -->
+                </ul>
+            </div>
+            <div class="actions">
+                <button id="addDreamButton">Add New Dream</button>
+            </div>
+        </div>
+
+        <script src="/static/js/dashboard.js"></script>
+    </body>
+{% endblock %}

--- a/dreamsApp/app/templates/dashboard/dashboard.html
+++ b/dreamsApp/app/templates/dashboard/dashboard.html
@@ -3,19 +3,10 @@
 {% block content %}
     <body> 
         <div class="container">
-            <h1>Welcome to Your Dashboard</h1>
-            <p>Here you can manage your dreams and view your progress.</p>
-            <div class="dreams-list">
-                <h2>Your Dreams</h2>
-                <!-- Placeholder for dreams list -->
-                <ul id="dreamsList">
-                    <!-- Dreams will be dynamically inserted here -->
-                </ul>
-            </div>
-            <div class="actions">
-                <button id="addDreamButton">Add New Dream</button>
-            </div>
-        </div>
+        <body>
+            <h2>User Sentiment Trend</h2>
+            <img src="data:image/png;base64,{{ plot_url }}" alt="Trend Plot">
+        </body>
 
         <script src="/static/js/dashboard.js"></script>
     </body>

--- a/dreamsApp/app/utils/sentiment.py
+++ b/dreamsApp/app/utils/sentiment.py
@@ -50,7 +50,7 @@ def get_image_caption_and_sentiment(image_path_or_url: str, caption: str,  promp
     img_caption = blip_processor.decode(out[0], skip_special_tokens=True)
 
     # Sentiment Analysis
-    combined_text = f"{caption} {img_caption}"
+    combined_text = f"{caption}"
     processed_text = preprocess(combined_text)
     encoded_input = sentiment_tokenizer(processed_text, return_tensors="pt")
     with torch.no_grad():


### PR DESCRIPTION
Introduced a new feature to plot user sentiment over time based on stored post sentiments.

- Built the logic to fetch sentiment-labeled posts from MongoDB and turn them into a timeline of scores.
- The graph shows cumulative sentiment, rolling average, and EMA, giving a clearer picture of mental health trends
- Set up some basic HTML structure and integrated the plot into the Flask app using base64 rendering so it shows up directly on the web page.


![ ](https://github.com/user-attachments/assets/dbe40515-cce5-41ea-b843-9b3fb441f3bc)

