### PR TITLE
Add Sentiment-Associated Keyword Word Cloud Visualization for Uploaded Images

### DIFF
--- a/dreamsApp/app/ingestion/routes.py
+++ b/dreamsApp/app/ingestion/routes.py
@@ -6,6 +6,7 @@ from flask import current_app
 from .  import bp
 
 from app.utils.sentiment import get_image_caption_and_sentiment
+from dreamsApp.app.utils.keywords import extract_keywords
 
 @bp.route('/upload', methods=['POST'])
 def upload_post():
@@ -22,8 +23,12 @@ def upload_post():
     image_path = os.path.join(upload_path, filename)
     image.save(image_path)
     result = get_image_caption_and_sentiment(image_path, caption)
+    
     sentiment = result["sentiment"]
     generated_caption = result["imgcaption"]
+    # keyword generation from the caption
+    keywords = extract_keywords(caption)
+    
 
     post_doc = {
         'user_id': user_id,

--- a/dreamsApp/app/templates/dashboard/profile.html
+++ b/dreamsApp/app/templates/dashboard/profile.html
@@ -1,12 +1,44 @@
 
 {% extends 'base.html' %}
 {% block content %}
-    <body> 
+
         <div class="container">
-        <body>
-            <h2>User Sentiment Trend</h2>
-            <img src="data:image/png;base64,{{ plot_url }}" alt="Trend Plot">
-        </body>
+            <div class="row">
+            <div class="col-md-12 text-center">
+                <h2>User Sentiment Trend</h2>
+                <img src="data:image/png;base64,{{ plot_url }}" alt="Trend Plot" class="img-fluid">
+            </div>
+            </div>
+            <div class="row">
+            <div class="col-md-6 text-center">
+                <h2>Positive Feelings  With</h2>
+                <img src="data:image/png;base64,{{ positive_wordcloud_url }}" alt="Positive Word Cloud" class="img-fluid" style="padding-bottom: 20px;">
+            </div>
+            <div class="col-md-6 text-center">
+                <h2>Negative Feelings With</h2>
+                <img src="data:image/png;base64,{{ negative_wordcloud_url }}" alt="Negative Word Cloud" class="img-fluid" style="padding-bottom: 20px;">
+            </div>
+            </div>
+        </div>
+        <style>
+            .container {
+            margin-top: 20px;
+            }
+            .text-center {
+            text-align: center;
+            }
+            .img-fluid {
+            max-width: 100%;
+            height: auto;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            padding: 5px;
+            }
+            h2 {
+            color: #333;
+            margin-bottom: 20px;
+            }
+        </style>
 
         <script src="/static/js/dashboard.js"></script>
     </body>

--- a/dreamsApp/app/utils/keywords.py
+++ b/dreamsApp/app/utils/keywords.py
@@ -1,0 +1,108 @@
+import spacy
+
+nlp = spacy.load("en_core_web_lg")
+
+def extract_keyword(sentence):
+    doc = nlp(sentence)
+    main_concepts = set()
+
+    
+    custom_excluded_words = {"me", "my", "i", "used", "when", "this", "parents", "bring", "sick", "got", "reminds"}
+
+    relevant_entity_labels = ["PERSON", "NORP", "ORG", "GPE", "LOC", "PRODUCT", "EVENT", "DATE", "WORK_OF_ART", "LAW", "LANGUAGE"]
+
+    extracted_entities = set()
+    for ent in doc.ents:
+        if ent.label_ in relevant_entity_labels:
+            extracted_entities.add(ent.text.lower())
+    main_concepts.update(extracted_entities)
+
+    extracted_noun_chunks = set()
+    for chunk in doc.noun_chunks:
+        
+        if any(not token.is_stop and not token.is_punct for token in chunk) and len(chunk.text.strip()) > 2:
+            chunk_text_lower = chunk.text.lower()
+            
+            if len(chunk) == 1 and chunk.root.pos_ == "NOUN":
+                extracted_noun_chunks.add(chunk.root.lemma_.lower())
+            else:
+                extracted_noun_chunks.add(chunk_text_lower)
+
+    main_concepts.update(extracted_noun_chunks)
+
+
+    
+    for token in doc:
+        if token.pos_ in ["NOUN", "PROPN"] and \
+           not token.is_stop and \
+           not token.is_punct and \
+           token.lemma_.lower() not in custom_excluded_words and \
+           len(token.lemma_.strip()) > 2: # Exclude very short lemmas
+
+            
+            is_redundant = False
+            token_lemma_lower = token.lemma_.lower()
+
+            for existing_concept in main_concepts.copy(): # Iterate over a copy to avoid modification issues
+                # If the individual noun is already the same as an existing concept
+                if token_lemma_lower == existing_concept:
+                    is_redundant = True
+                    break
+                if len(existing_concept.split()) > 1 and token_lemma_lower in existing_concept:
+                    if token_lemma_lower in [word.lemma_.lower() for word in nlp(existing_concept) if word.pos_ in ["NOUN", "PROPN"]]:
+                        is_redundant = True
+                        break
+
+            if not is_redundant:
+                main_concepts.add(token_lemma_lower)
+
+    
+    final_filtered_concepts = set()
+    concepts_list = sorted(list(main_concepts), key=len, reverse=True)
+
+    for i, concept_i in enumerate(concepts_list):
+        is_substring_of_another = False
+        for j, concept_j in enumerate(concepts_list):
+            if i != j and concept_i in concept_j and len(concept_i.split()) < len(concept_j.split()):
+                
+                is_substring_of_another = True
+                break
+        if not is_substring_of_another:
+            final_filtered_concepts.add(concept_i)
+
+    
+    final_final_concepts = [c for c in list(final_filtered_concepts) if c not in custom_excluded_words and len(c.strip()) > 2]
+
+
+    return sorted(list(final_final_concepts))
+
+# # --- Test Cases ---
+# sentence1 = "This hospital reminds me of my childhood, my parents used to bring me when I got sick."
+# print(f"Sentence 1: '{sentence1}'")
+# print("Main Things:", extract_aspects(sentence1))
+# # Expected: ['childhood', 'hospital'] (or 'my childhood', 'this hospital' if preferred noun chunks)
+
+# sentence2 = "The quick brown fox jumps over the lazy dog."
+# print(f"\nSentence 2: '{sentence2}'")
+# print("Main Things:", extract_aspects(sentence2))
+# # Expected: ['brown fox', 'lazy dog'] or ['dog', 'fox'] if simpler.
+
+# sentence3 = "The new Apple iPhone 15 has an amazing camera and long battery life."
+# print(f"\nSentence 3: '{sentence3}'")
+# print("Main Things:", extract_aspects(sentence3))
+# # Expected: ['apple iphone 15', 'battery life', 'camera']
+
+# sentence4 = "My son loves playing with his toy cars and trains."
+# print(f"\nSentence 4: '{sentence4}'")
+# print("Main Things:", extract_aspects(sentence4))
+# # Expected: ['son', 'toy cars', 'trains', 'cars'] or ['son', 'toy cars', 'trains']
+
+# sentence5 = "I went to New York City and visited Central Park."
+# print(f"\nSentence 5: '{sentence5}'")
+# print("Main Things:", extract_aspects(sentence5))
+# # Expected: ['central park', 'new york city']
+
+# sentence6 = "The doctor performed a successful surgery on the patient's knee."
+# print(f"\nSentence 6: '{sentence6}'")
+# print("Main Things:", extract_aspects(sentence6))
+# # Expected: ['doctor', 'knee', 'patient', 'surgery']

--- a/dreamsApp/app/utils/sentiment.py
+++ b/dreamsApp/app/utils/sentiment.py
@@ -73,30 +73,3 @@ def get_image_caption_and_sentiment(image_path_or_url: str, caption: str,  promp
         "imgcaption": img_caption,
         "sentiment": top_sentiment  
     }
-
-def get_aspect(caption):
-    absa_model = AbsaModel.from_pretrained(
-        ASPECT_MODEL_ID,
-        POLARITY_MODEL_ID,
-        spacy_model="en_core_web_lm " # Pass as a keyword argument
-    )
-    if absa_model is None:
-        print("ABSA model is not initialized. Cannot perform aspect extraction.")
-        return None
-
-    # model.predict expects a list of strings
-    sentences = [caption]
-    aspects_predictions = absa_model.predict(sentences)
-
-    print(f"Full prediction output: {aspects_predictions}")
-
-    # The 'aspects_predictions' will be a list of dictionaries, one for each sentence.
-    # Each dictionary has a 'spans' key, which is a list of identified aspects.
-    # We want the 'spans' for the first (and only) sentence.
-    if aspects_predictions and 'spans' in aspects_predictions[0]:
-        extracted_spans = aspects_predictions[0]['spans']
-        print(f"Extracted aspects: {extracted_spans}")
-        return extracted_spans
-    else:
-        print("No aspects found or unexpected prediction format.")
-        return [] 


### PR DESCRIPTION
This PR adds a new feature that visualizes what things, people, or places are associated with users’ positive and negative feelings in the DREAMS project. The goal is to help researchers identify emotional patterns from user-submitted photos.

When a user uploads an image:

- We use Salesforce BLIP to generate a caption or descriptive text.
- Then, we extract noun-like keywords (people, places, objects) using spaCy NLP pipeline.
- These extracted keywords are stored in the database along with their associated sentiment (positive or negative), based on the caption sentiment score.

On the user profile page, we:

- Fetch all stored keywords grouped by sentiment.
- Render separate word clouds for positive and negative associations.

This helps researchers:

- Understand where the user feels happy/safe (e.g., “park”, “mom”, “home”).
- Detect emotional stressors (e.g., “hospital”, “police”, “bus stop”).

New DB Field:
```
{
  "user_id": "<user_id>",
  "positive_keywords": ["beach", "mom", "dog"],
  "negative_keywords": ["hospital", "dark", "police"]
}
```
<img width="1914" height="1010" alt="Screenshot from 2025-08-01 01-44-31" src="https://github.com/user-attachments/assets/b7552d86-d933-47b1-8d7c-f41241b644c7" />



