### PR TITLE
Weighted edges with temporal proximity scoring in narrative graph 

### DIFF
--- a/docs/narrative-structure-analysis.md
+++ b/docs/narrative-structure-analysis.md
@@ -150,7 +150,7 @@ Each edge carries a `weight` field (0.0–1.0) that quantifies connection streng
 | Relation | Weight Formula | Intuition |
 |----------|---------------|----------|
 | `overlapping` | Always `1.0` | Simultaneous episodes are maximally connected |
-| `adjacent` | `1.0 − gap / threshold` | Linearly decreases as the gap grows; touching episodes get 1.0, episodes near the threshold get ~0.0 |
+| `adjacent` | `1.0 − gap / threshold` | Linearly decreases as the gap grows; touching episodes get 1.0, episodes at the threshold get 0.0 |
 | `disjoint` | Always `0.0` | No meaningful temporal connection |
 
 The weight is computed by `_compute_edge_weight()` and validated to stay within `[0.0, 1.0]`.

--- a/docs/narrative-structure-analysis.md
+++ b/docs/narrative-structure-analysis.md
@@ -128,6 +128,7 @@ Edge creation rule:
 - For every pair of episodes (i, j) where i < j
 - Classify their temporal relationship using `adjacency_threshold`
 - If they overlap or are adjacent (gap ≤ threshold) → create an edge
+- Assign a **weight** (0.0–1.0) reflecting connection strength
 
 The `adjacency_threshold` controls how far apart two episodes can be and still get connected.
 
@@ -137,10 +138,22 @@ The `adjacency_threshold` controls how far apart two episodes can be and still g
 
 Edge types (from `ProximityRelation`):
 | Relation | Meaning |
-|----------|---------|
+|----------|--------|
 | `overlapping` | The episodes overlap in time |
 | `adjacent` | The gap between them is ≤ adjacency_threshold |
 | `disjoint` | The gap is > adjacency_threshold (edge NOT created by default) |
+
+#### Edge Weights
+
+Each edge carries a `weight` field (0.0–1.0) that quantifies connection strength based on temporal proximity:
+
+| Relation | Weight Formula | Intuition |
+|----------|---------------|----------|
+| `overlapping` | Always `1.0` | Simultaneous episodes are maximally connected |
+| `adjacent` | `1.0 − gap / threshold` | Linearly decreases as the gap grows; touching episodes get 1.0, episodes near the threshold get ~0.0 |
+| `disjoint` | Always `0.0` | No meaningful temporal connection |
+
+The weight is computed by `_compute_edge_weight()` and validated to stay within `[0.0, 1.0]`.
 
 The graph is always a **DAG** (directed acyclic graph) because edges only go from lower-index to higher-index episodes (earlier → later in time).
 
@@ -165,7 +178,7 @@ Converts the `TemporalNarrativeGraph` to a networkx `DiGraph` via `to_networkx()
 | `degree_centrality` | Fraction of other nodes this episode is connected to |
 | `in_degree_centrality` | How many earlier episodes connect to this one |
 | `out_degree_centrality` | How many later episodes this one connects to |
-| `betweenness_centrality` | How often this episode lies on shortest paths between others (higher = more of a "bridge") |
+| `betweenness_centrality` | How often this episode lies on shortest paths between others (weighted — shorter temporal gaps count as shorter paths) |
 | `emotion_label` | Dominant emotion label across the episode's events |
 | `event_count` | Number of posts in this episode |
 
@@ -186,9 +199,12 @@ The raw directed edge list is also returned so the frontend can render the exact
 {
     "source": 3,
     "target": 4,
-    "relation": "adjacent"
+    "relation": "adjacent",
+    "weight": 0.7143
 }
 ```
+
+The `weight` field (0.0–1.0) is rounded to 4 decimal places. It is used by both `betweenness_centrality` computation and the D3 visualization.
 
 ---
 
@@ -232,7 +248,8 @@ result = analyze_narrative_graph(narrative_graph)
         {
             "source": 0,
             "target": 1,
-            "relation": "adjacent"
+            "relation": "adjacent",
+            "weight": 0.8571
         }
     ],
     "pattern_analysis": {
@@ -319,11 +336,17 @@ Four cards showing at-a-glance metrics:
 
 #### 2. Interactive Force-Directed Graph (D3.js v7)
 - Each **node** = one episode
-- **Node color**: green (positive), red (negative), grey (neutral)
+- **Node color**: teal-green (positive), coral-red (negative), blue-grey (neutral)
 - **Node size**: proportional to betweenness centrality (bigger = more important as a bridge)
-- **Edges**: directed arrows showing temporal flow
+- **Node effects**: drop shadow for depth; glow effect on hover; stroke color derived from emotion
+- **Edges**: curved arc paths with directed arrows showing temporal flow
+- **Edge thickness**: proportional to edge weight (stronger temporal connection = thicker line, 0.6–2.5px)
+- **Edge opacity**: proportional to edge weight (0.25–0.80)
+- **Edge color**: tinted by source node's emotion color
+- **Arrow markers**: sleek small arrows; lighter variant for low-weight edges (≤ 0.4)
 - **Draggable** nodes — user can rearrange the layout
 - **Hover tooltips**: episode index, emotion, event count, timestamps, centrality values
+- **Adaptive layout**: link distance and charge repulsion scale with node count for consistent spacing
 
 #### 3. Centrality Bar Chart (Chart.js 4)
 - Horizontal bar chart showing betweenness centrality per episode
@@ -347,7 +370,9 @@ Four cards showing at-a-glance metrics:
 - Page loads with a spinner, then fetches from `/api/analytics/graph-metrics/<user_id>` via `fetch()`
 - All rendering is **client-side** (D3 + Chart.js) — no matplotlib blocking
 - Uses CDN-loaded libraries (no local static files needed)
-- Dark theme matching the rest of the dashboard
+- Dark theme with radial gradient background for the graph container
+- SVG filters (`feDropShadow`, `feGaussianBlur`) for node depth and hover glow
+- D3 force simulation uses adaptive parameters: `velocityDecay(0.35)`, `alphaDecay(0.02)` for smooth settling
 
 ---
 
@@ -401,7 +426,8 @@ These are currently hardcoded but can be made configurable via `app.config` in t
 ### Tests
 | File | Test Count | Scope |
 |------|-----------|-------|
-| `tests/test_graph_analysis.py` | 32 | Unit tests for all metric computations + edges + to_networkx() |
+| `tests/test_graph_analysis.py` | 33 | Unit tests for all metric computations + edges + weighted edges + to_networkx() |
+| `tests/test_temporal_narrative_graph.py` | 41 | Unit tests for episodes, proximity, narrative edges, edge weights, graph construction |
 | `tests/test_graph_metrics_api.py` | 9 | Integration tests for API endpoint + dashboard route |
 
 ---
@@ -420,13 +446,22 @@ python -m pytest tests/test_graph_analysis.py tests/test_graph_metrics_api.py te
 
 ### Test coverage breakdown
 
-**Unit tests (`test_graph_analysis.py` — 32 tests):**
+**Unit tests (`test_graph_analysis.py` — 33 tests):**
 - Input validation (TypeError on wrong types, empty graph returns zeroed response)
 - Graph summary accuracy (density, components, edge count)
 - Node metrics (centrality values, emotion label derivation, ISO timestamp format)
 - Pattern analysis (transition sorting, cycle detection, label distribution)
-- Edge response (count matches summary, correct structure, DAG ordering)
-- `to_networkx()` (node/edge counts, attributes, empty graph handling)
+- Edge response (count matches summary, correct structure with weight field, DAG ordering)
+- `to_networkx()` (node/edge counts, attributes, edge weight propagation, empty graph handling)
+
+**Unit tests (`test_temporal_narrative_graph.py` — 41 tests):**
+- Episode immutability and temporal invariants
+- Episode segmentation (empty, single, gap-based splitting)
+- Episode proximity (overlap, gap, adjacency classification)
+- NarrativeEdge validation (ordering, index bounds, weight range 0.0–1.0)
+- Edge weight computation (overlapping→1.0, touching→1.0, gap decay, disjoint→0.0)
+- Graph construction (deterministic, immutable, node/edge queries)
+- Weight serialization in `to_dict()`
 
 **Integration tests (`test_graph_metrics_api.py` — 9 tests):**
 - 404 for missing user
@@ -463,6 +498,8 @@ python -m pytest tests/test_graph_analysis.py tests/test_graph_metrics_api.py te
 
 6. **Computation is O(N²)** — The `build_narrative_graph` function checks all pairs of episodes. For users with hundreds of episodes, this becomes slow. Currently fine for typical usage (10–50 posts).
 
+7. **Weights are purely temporal** — Edge weights are based solely on time-gap proximity. Semantic similarity between episode content is not yet factored in. A future "temporo-semantic" model could combine temporal weight with text embedding cosine similarity for richer connections.
+
 ---
 
 ## Future Roadmap
@@ -476,4 +513,5 @@ python -m pytest tests/test_graph_analysis.py tests/test_graph_metrics_api.py te
 | **Phase 3** | Alert system for negative cycles | Flag users stuck in recurring negative loops |
 | **Phase 3** | Graph metrics as ML features | Feed centrality/density into predictive models |
 | **Phase 3** | CHIME-dimension integration | Use CHIME labels instead of just positive/negative/neutral for richer analysis |
+| **Phase 3** | Semantic similarity edges | Combine temporal proximity with text embedding cosine similarity for temporo-semantic edge weights |
 | **Phase 4** | Research data export (CSV/GraphML) | Researchers can download graph data for external analysis and papers |

--- a/dreamsApp/analytics/graph_analysis.py
+++ b/dreamsApp/analytics/graph_analysis.py
@@ -106,6 +106,7 @@ def _compute_edges(G: nx.DiGraph) -> List[Dict[str, Any]]:
             "source": u,
             "target": v,
             "relation": attrs.get("relation", ""),
+            "weight": round(attrs.get("weight", 1.0), 4),
         })
     return edges
 
@@ -127,7 +128,7 @@ def _compute_node_metrics(G: nx.DiGraph) -> List[Dict[str, Any]]:
     degree_cent = nx.degree_centrality(G)
     in_degree_cent = nx.in_degree_centrality(G)
     out_degree_cent = nx.out_degree_centrality(G)
-    betweenness_cent = nx.betweenness_centrality(G)
+    betweenness_cent = nx.betweenness_centrality(G, weight='weight')
 
     metrics: List[Dict[str, Any]] = []
     for i in sorted(G.nodes()):

--- a/dreamsApp/analytics/temporal_narrative_graph.py
+++ b/dreamsApp/analytics/temporal_narrative_graph.py
@@ -5,7 +5,12 @@ from datetime import timedelta
 from typing import Tuple, List, Dict, Any, Optional
 
 from .emotion_episode import Episode
-from .episode_proximity import ProximityRelation, classify_episode_proximity
+from .episode_proximity import (
+    ProximityRelation,
+    classify_episode_proximity,
+    compute_temporal_gap,
+    compute_temporal_overlap,
+)
 
 
 __all__ = [
@@ -20,6 +25,7 @@ class NarrativeEdge:
     source_index: int
     target_index: int
     relation: ProximityRelation
+    weight: float = 1.0
     
     def __post_init__(self) -> None:
         if self.source_index < 0 or self.target_index < 0:
@@ -32,12 +38,17 @@ class NarrativeEdge:
                 f"source_index must be less than target_index for canonical ordering: "
                 f"{self.source_index} >= {self.target_index}"
             )
+        if not (0.0 <= self.weight <= 1.0):
+            raise ValueError(
+                f"weight must be between 0.0 and 1.0, got {self.weight}"
+            )
     
     def to_dict(self) -> Dict[str, Any]:
         return {
             'source_index': self.source_index,
             'target_index': self.target_index,
             'relation': self.relation.value,
+            'weight': self.weight,
         }
 
 
@@ -86,6 +97,7 @@ class TemporalNarrativeGraph:
         Edge attributes:
             - relation: str — the ProximityRelation.value
               ('overlapping', 'adjacent', 'disjoint').
+            - weight: float — connection strength (0.0–1.0).
 
         Returns:
             networkx.DiGraph
@@ -117,6 +129,7 @@ class TemporalNarrativeGraph:
                 edge.source_index,
                 edge.target_index,
                 relation=edge.relation.value,
+                weight=edge.weight,
             )
         
         return G
@@ -172,10 +185,14 @@ def build_narrative_graph(
             )
             
             if relation != ProximityRelation.DISJOINT or include_disjoint_edges:
+                weight = _compute_edge_weight(
+                    nodes[i], nodes[j], relation, adjacency_threshold
+                )
                 edge = NarrativeEdge(
                     source_index=i,
                     target_index=j,
-                    relation=relation
+                    relation=relation,
+                    weight=weight,
                 )
                 edges.append(edge)
     
@@ -184,3 +201,34 @@ def build_narrative_graph(
         edges=tuple(edges),
         adjacency_threshold=adjacency_threshold
     )
+
+
+def _compute_edge_weight(
+    ep_a: Episode,
+    ep_b: Episode,
+    relation: ProximityRelation,
+    adjacency_threshold: timedelta,
+) -> float:
+    """Compute a 0.0–1.0 connection-strength weight for an edge.
+
+    - **Overlapping** episodes get weight 1.0 (strongest possible link).
+    - **Adjacent** episodes are scored as ``1 - gap / threshold``, giving
+      1.0 for touching episodes and approaching 0.0 as the gap nears the
+      threshold.
+    - **Disjoint** edges (only present when *include_disjoint_edges* is
+      True) always receive 0.0.
+    """
+    if relation == ProximityRelation.OVERLAPPING:
+        return 1.0
+
+    if relation == ProximityRelation.DISJOINT:
+        return 0.0
+
+    # Adjacent — weight decreases linearly with the gap.
+    threshold_secs = adjacency_threshold.total_seconds()
+    if threshold_secs == 0:
+        # Zero threshold means only touching episodes qualify; gap is 0.
+        return 1.0
+
+    gap_secs = compute_temporal_gap(ep_a, ep_b)
+    return max(0.0, 1.0 - gap_secs / threshold_secs)

--- a/dreamsApp/app/templates/dashboard/narrative.html
+++ b/dreamsApp/app/templates/dashboard/narrative.html
@@ -524,8 +524,15 @@
 
         // Simulation — spread nodes apart for clarity
         const nCount = nodes.length;
-        const linkDist = Math.max(120, 50 + nCount * 8);   // adaptive spacing
-        const chargeStr = Math.min(-300, -150 - nCount * 15); // stronger repulsion for more nodes
+        const MIN_LINK_DISTANCE = 120;
+        const BASE_LINK_DISTANCE = 50;
+        const LINK_DISTANCE_PER_NODE = 8;
+        const MAX_CHARGE_STRENGTH = -300;
+        const BASE_CHARGE_STRENGTH = -150;
+        const CHARGE_PER_NODE = -15;
+
+        const linkDist = Math.max(MIN_LINK_DISTANCE, BASE_LINK_DISTANCE + nCount * LINK_DISTANCE_PER_NODE);   // adaptive spacing
+        const chargeStr = Math.min(MAX_CHARGE_STRENGTH, BASE_CHARGE_STRENGTH + nCount * CHARGE_PER_NODE); // stronger repulsion for more nodes
 
         const simulation = d3.forceSimulation(nodes)
             .force("link", d3.forceLink(links).id(d => d.id).distance(linkDist).strength(0.4))
@@ -537,8 +544,9 @@
             .velocityDecay(0.35)
             .alphaDecay(0.02);
 
-        // Scale edge stroke-width by weight (0–1 → 0.6px–2.5px)
-        const wScale = d3.scaleLinear().domain([0, 1]).range([0.6, 2.5]).clamp(true);
+        // Scale edge properties by weight
+        const wScale       = d3.scaleLinear().domain([0, 1]).range([0.6, 2.5]).clamp(true);  // stroke-width
+        const opacityScale = d3.scaleLinear().domain([0, 1]).range([0.25, 0.80]).clamp(true); // stroke-opacity
 
         // Links — curved paths for a more organic look
         const link = svg.append("g")
@@ -553,7 +561,7 @@
                 return src ? emotionColor(src.label) + "55" : "#44445580";
             })
             .attr("stroke-width", d => wScale(d.weight))
-            .attr("stroke-opacity", d => 0.25 + 0.55 * d.weight)
+            .attr("stroke-opacity", d => opacityScale(d.weight))
             .attr("marker-end", d => d.weight > 0.4 ? "url(#arrow)" : "url(#arrow-light)");
 
         // Nodes

--- a/dreamsApp/app/templates/dashboard/narrative.html
+++ b/dreamsApp/app/templates/dashboard/narrative.html
@@ -69,7 +69,7 @@
     #narrative-graph svg {
         display: block;
         width: 100%;
-        height: 520px;
+        height: 600px;
     }
 
     /* ── Legend ── */
@@ -215,9 +215,9 @@
     }
 
     /* ── Legend swatches (one per emotion) ── */
-    .legend-swatch-positive { background: #66bb6a; }
-    .legend-swatch-negative { background: #ef5350; }
-    .legend-swatch-neutral  { background: #78909c; }
+    .legend-swatch-positive { background: #4dd0a1; }
+    .legend-swatch-negative { background: #ff6b6b; }
+    .legend-swatch-neutral  { background: #90a4ae; }
 
     /* ── Chart panel typography ── */
     .chart-title {
@@ -395,12 +395,12 @@
 
     // ── Colour Palette ──
     const EMOTION_COLORS = {
-        positive: "#66bb6a",
-        negative: "#ef5350",
-        neutral:  "#78909c",
+        positive: "#4dd0a1",
+        negative: "#ff6b6b",
+        neutral:  "#90a4ae",
     };
 
-    const fallbackColor = "#555";
+    const fallbackColor = "#666";
 
     function emotionColor(label) {
         return EMOTION_COLORS[(label || "").toLowerCase()] || fallbackColor;
@@ -453,7 +453,7 @@
         }
 
         const width  = container.clientWidth;
-        const height = 520;
+        const height = 600;
 
         // Build node data
         const nodes = nodeMetrics.map(n => ({
@@ -471,47 +471,90 @@
             source: e.source,
             target: e.target,
             relation: e.relation || "",
+            weight: Math.max(0, Math.min(1, Number(e.weight) || 0)),
         }));
 
         // Scale node radius by betweenness centrality
         const maxBC = d3.max(nodes, n => n.bc) || 1;
-        const rScale = d3.scaleLinear().domain([0, maxBC]).range([8, 28]);
+        const rScale = d3.scaleLinear().domain([0, maxBC]).range([10, 30]).clamp(true);
+
+        // O(1) node lookup by id for edge colouring
+        const nodeById = new Map(nodes.map(n => [n.id, n]));
 
         const svg = d3.select(container)
             .append("svg")
             .attr("viewBox", `0 0 ${width} ${height}`)
             .attr("preserveAspectRatio", "xMidYMid meet");
 
-        // Arrow marker
-        svg.append("defs").append("marker")
+        // SVG filters — drop shadow for nodes, glow for hover
+        const defs = svg.append("defs");
+
+        const dropShadow = defs.append("filter").attr("id", "drop-shadow").attr("x", "-40%").attr("y", "-40%").attr("width", "180%").attr("height", "180%");
+        dropShadow.append("feDropShadow").attr("dx", 0).attr("dy", 2).attr("stdDeviation", 3).attr("flood-color", "rgba(0,0,0,0.5)");
+
+        const glow = defs.append("filter").attr("id", "glow").attr("x", "-50%").attr("y", "-50%").attr("width", "200%").attr("height", "200%");
+        glow.append("feGaussianBlur").attr("stdDeviation", 4).attr("result", "blur");
+        glow.append("feMerge").selectAll("feMergeNode").data(["blur", "SourceGraphic"]).join("feMergeNode").attr("in", d => d);
+
+        // Arrow marker — sleek and small
+        defs.append("marker")
             .attr("id", "arrow")
-            .attr("viewBox", "0 -5 10 10")
-            .attr("refX", 20)
+            .attr("viewBox", "0 -4 8 8")
+            .attr("refX", 22)
             .attr("refY", 0)
-            .attr("markerWidth", 6)
-            .attr("markerHeight", 6)
+            .attr("markerWidth", 4)
+            .attr("markerHeight", 4)
             .attr("orient", "auto")
             .append("path")
-            .attr("d", "M0,-5L10,0L0,5")
+            .attr("d", "M0,-4L8,0L0,4")
+            .attr("fill", "#666");
+
+        // Subtle arrow for thin edges
+        defs.append("marker")
+            .attr("id", "arrow-light")
+            .attr("viewBox", "0 -3 6 6")
+            .attr("refX", 22)
+            .attr("refY", 0)
+            .attr("markerWidth", 3)
+            .attr("markerHeight", 3)
+            .attr("orient", "auto")
+            .append("path")
+            .attr("d", "M0,-3L6,0L0,3")
             .attr("fill", "#555");
 
-        // Simulation
-        const simulation = d3.forceSimulation(nodes)
-            .force("link", d3.forceLink(links).id(d => d.id).distance(90))
-            .force("charge", d3.forceManyBody().strength(-250))
-            .force("center", d3.forceCenter(width / 2, height / 2))
-            .force("y", d3.forceY(height / 2).strength(0.06))
-            .force("x", d3.forceX(width / 2).strength(0.06))
-            .force("collision", d3.forceCollide().radius(d => rScale(d.bc) + 4));
+        // Simulation — spread nodes apart for clarity
+        const nCount = nodes.length;
+        const linkDist = Math.max(120, 50 + nCount * 8);   // adaptive spacing
+        const chargeStr = Math.min(-300, -150 - nCount * 15); // stronger repulsion for more nodes
 
-        // Links
+        const simulation = d3.forceSimulation(nodes)
+            .force("link", d3.forceLink(links).id(d => d.id).distance(linkDist).strength(0.4))
+            .force("charge", d3.forceManyBody().strength(chargeStr).distanceMax(400))
+            .force("center", d3.forceCenter(width / 2, height / 2))
+            .force("y", d3.forceY(height / 2).strength(0.04))
+            .force("x", d3.forceX(width / 2).strength(0.04))
+            .force("collision", d3.forceCollide().radius(d => rScale(d.bc) + 12))
+            .velocityDecay(0.35)
+            .alphaDecay(0.02);
+
+        // Scale edge stroke-width by weight (0–1 → 0.6px–2.5px)
+        const wScale = d3.scaleLinear().domain([0, 1]).range([0.6, 2.5]).clamp(true);
+
+        // Links — curved paths for a more organic look
         const link = svg.append("g")
-            .selectAll("line")
+            .selectAll("path")
             .data(links)
-            .join("line")
-            .attr("stroke", "#444")
-            .attr("stroke-width", 1.5)
-            .attr("marker-end", "url(#arrow)");
+            .join("path")
+            .attr("fill", "none")
+            .attr("stroke", d => {
+                // tint edge colour by source emotion (O(1) Map lookup)
+                const srcId = d.source.id != null ? d.source.id : d.source;
+                const src = nodeById.get(srcId);
+                return src ? emotionColor(src.label) + "55" : "#44445580";
+            })
+            .attr("stroke-width", d => wScale(d.weight))
+            .attr("stroke-opacity", d => 0.25 + 0.55 * d.weight)
+            .attr("marker-end", d => d.weight > 0.4 ? "url(#arrow)" : "url(#arrow-light)");
 
         // Nodes
         const node = svg.append("g")
@@ -520,22 +563,28 @@
             .join("circle")
             .attr("r", d => rScale(d.bc))
             .attr("fill", d => emotionColor(d.label))
-            .attr("stroke", "#222")
-            .attr("stroke-width", 2)
+            .attr("stroke", d => d3.color(emotionColor(d.label)).brighter(0.8))
+            .attr("stroke-width", 1.5)
+            .attr("filter", "url(#drop-shadow)")
             .style("cursor", "pointer")
-            .call(drag(simulation));
+            .style("transition", "filter 0.2s ease")
+            .call(drag(simulation))
+            .on("mouseenter", function () { d3.select(this).attr("filter", "url(#glow)").raise(); })
+            .on("mouseleave", function () { d3.select(this).attr("filter", "url(#drop-shadow)"); });
 
         // Node index labels
-        svg.append("g")
+        const labels = svg.append("g")
             .selectAll("text")
             .data(nodes)
             .join("text")
             .text(d => d.id)
-            .attr("font-size", 10)
+            .attr("font-size", d => Math.max(10, rScale(d.bc) * 0.65))
+            .attr("font-weight", 600)
             .attr("fill", "#fff")
             .attr("text-anchor", "middle")
-            .attr("dy", 4)
-            .style("pointer-events", "none");
+            .attr("dy", ".35em")
+            .style("pointer-events", "none")
+            .style("text-shadow", "0 1px 3px rgba(0,0,0,0.7)");
 
         // Tooltip
         const tooltip = d3.select("body").append("div").attr("class", "graph-tooltip").style("display", "none");
@@ -560,21 +609,25 @@
             })
             .on("mouseout", () => tooltip.style("display", "none"));
 
+        // Curved-link path generator
+        function linkArc(d) {
+            const dx = d.target.x - d.source.x;
+            const dy = d.target.y - d.source.y;
+            const dr = Math.sqrt(dx * dx + dy * dy) * 1.6;  // arc radius
+            return `M${d.source.x},${d.source.y}A${dr},${dr} 0 0,1 ${d.target.x},${d.target.y}`;
+        }
+
         // Tick update
         simulation.on("tick", () => {
-            link
-                .attr("x1", d => d.source.x)
-                .attr("y1", d => d.source.y)
-                .attr("x2", d => d.target.x)
-                .attr("y2", d => d.target.y);
+            link.attr("d", linkArc);
 
             node
                 .attr("cx", d => d.x = clamp(d.x, 30, width - 30))
                 .attr("cy", d => d.y = clamp(d.y, 30, height - 30));
 
-            svg.selectAll("text")
-                .attr("x", (d, i) => nodes[i] ? nodes[i].x : 0)
-                .attr("y", (d, i) => nodes[i] ? nodes[i].y : 0);
+            labels
+                .attr("x", d => d.x)
+                .attr("y", d => d.y);
         });
 
         function drag(sim) {

--- a/tests/test_graph_analysis.py
+++ b/tests/test_graph_analysis.py
@@ -373,6 +373,24 @@ class TestToNetworkx:
             assert "relation" in data
             assert data["relation"] in ("overlapping", "adjacent", "disjoint")
 
+    def test_networkx_edge_has_weight(self, base_time):
+        ep1 = Episode(
+            start_time=base_time,
+            end_time=base_time + timedelta(hours=2),
+            events=(),
+        )
+        ep2 = Episode(
+            start_time=base_time + timedelta(hours=1),
+            end_time=base_time + timedelta(hours=3),
+            events=(),
+        )
+        graph = build_narrative_graph([ep1, ep2])
+        G = graph.to_networkx()
+
+        for u, v, data in G.edges(data=True):
+            assert "weight" in data
+            assert 0.0 <= data["weight"] <= 1.0
+
     def test_empty_graph_to_networkx(self):
         graph = build_narrative_graph([])
         G = graph.to_networkx()
@@ -424,7 +442,9 @@ class TestEdgesInResponse:
         assert "source" in edge
         assert "target" in edge
         assert "relation" in edge
+        assert "weight" in edge
         assert edge["source"] < edge["target"]  # DAG ordering
+        assert 0.0 <= edge["weight"] <= 1.0
 
     def test_disconnected_graph_has_no_edges(self, base_time):
         ep1 = make_episode(base_time, 0, 1, ["positive"])

--- a/tests/test_temporal_narrative_graph.py
+++ b/tests/test_temporal_narrative_graph.py
@@ -307,6 +307,34 @@ class TestNarrativeEdge:
         )
         assert edge.source_index == 0
         assert edge.target_index == 1
+        assert edge.weight == 1.0  # default
+    
+    def test_valid_edge_with_weight(self):
+        edge = NarrativeEdge(
+            source_index=0,
+            target_index=1,
+            relation=ProximityRelation.ADJACENT,
+            weight=0.5,
+        )
+        assert edge.weight == 0.5
+
+    def test_weight_out_of_range_raises(self):
+        with pytest.raises(ValueError, match="weight must be between"):
+            NarrativeEdge(
+                source_index=0,
+                target_index=1,
+                relation=ProximityRelation.ADJACENT,
+                weight=1.5,
+            )
+
+    def test_negative_weight_raises(self):
+        with pytest.raises(ValueError, match="weight must be between"):
+            NarrativeEdge(
+                source_index=0,
+                target_index=1,
+                relation=ProximityRelation.ADJACENT,
+                weight=-0.1,
+            )
     
     def test_invalid_ordering_raises(self):
         with pytest.raises(ValueError, match="source_index must be less than target_index"):
@@ -462,3 +490,92 @@ class TestTemporalNarrativeGraph:
         
         assert len(overlapping) >= 1
         assert all(e.relation == ProximityRelation.OVERLAPPING for e in overlapping)
+
+    def test_overlapping_edge_weight_is_one(self, base_time: datetime):
+        """Overlapping episodes should produce weight=1.0."""
+        ep1 = Episode(
+            start_time=base_time,
+            end_time=base_time + timedelta(hours=2),
+            events=()
+        )
+        ep2 = Episode(
+            start_time=base_time + timedelta(hours=1),
+            end_time=base_time + timedelta(hours=3),
+            events=()
+        )
+        graph = build_narrative_graph([ep1, ep2], adjacency_threshold=timedelta(hours=6))
+        assert graph.edges[0].weight == 1.0
+
+    def test_adjacent_touching_weight_is_one(self, base_time: datetime):
+        """Adjacent episodes with zero gap should produce weight=1.0."""
+        ep1 = Episode(
+            start_time=base_time,
+            end_time=base_time + timedelta(hours=1),
+            events=()
+        )
+        ep2 = Episode(
+            start_time=base_time + timedelta(hours=1),
+            end_time=base_time + timedelta(hours=2),
+            events=()
+        )
+        graph = build_narrative_graph([ep1, ep2], adjacency_threshold=timedelta(hours=6))
+        assert graph.edges[0].weight == 1.0
+
+    def test_adjacent_weight_decreases_with_gap(self, base_time: datetime):
+        """Larger gaps within the threshold should produce lower weights."""
+        ep1 = Episode(
+            start_time=base_time,
+            end_time=base_time + timedelta(hours=1),
+            events=()
+        )
+        ep_close = Episode(
+            start_time=base_time + timedelta(hours=2),
+            end_time=base_time + timedelta(hours=3),
+            events=()
+        )
+        ep_far = Episode(
+            start_time=base_time + timedelta(hours=5),
+            end_time=base_time + timedelta(hours=6),
+            events=()
+        )
+        threshold = timedelta(hours=6)
+        graph = build_narrative_graph([ep1, ep_close, ep_far], adjacency_threshold=threshold)
+
+        # ep1→ep_close has 1h gap (weight ≈ 0.833)
+        # ep1→ep_far has 4h gap (weight ≈ 0.333)
+        w_close = None
+        w_far = None
+        for edge in graph.edges:
+            if edge.source_index == 0 and edge.target_index == 1:
+                w_close = edge.weight
+            if edge.source_index == 0 and edge.target_index == 2:
+                w_far = edge.weight
+
+        assert w_close is not None and w_far is not None
+        assert w_close > w_far
+        assert 0.0 < w_far < w_close <= 1.0
+
+    def test_disjoint_edge_weight_is_zero(self, base_time: datetime):
+        """Disjoint edges (when included) should have weight 0.0."""
+        ep1 = Episode(
+            start_time=base_time,
+            end_time=base_time + timedelta(hours=1),
+            events=()
+        )
+        ep2 = Episode(
+            start_time=base_time + timedelta(hours=10),
+            end_time=base_time + timedelta(hours=11),
+            events=()
+        )
+        graph = build_narrative_graph([ep1, ep2], include_disjoint_edges=True)
+        assert graph.edges[0].weight == 0.0
+
+    def test_weight_in_to_dict(self):
+        edge = NarrativeEdge(
+            source_index=0,
+            target_index=1,
+            relation=ProximityRelation.ADJACENT,
+            weight=0.75,
+        )
+        d = edge.to_dict()
+        assert d['weight'] == 0.75


### PR DESCRIPTION
**Summary**

- Currently, an edge between two emotional episodes either exists or it doesn't. This pr adds connection strength weights to narrative graph edges. (build in #91)

- A weighted edge would represent the _strength_ of that connection. A short time gap between two emotion episodes would result in a high weight (strong) edge, while a larger gap would result in a low weight (weak) edge.

**Benefit**
This makes all your centrality calculations more accurate. A node's _betweenness_ is much more significant if it's a bridge between strongly connected components. It helps differentiate truly pivotal moments from minor transitions. This would help in getting clearer insights about the user's emotional journey.
