### PR TITLE
Implemented Reverse Geocoding

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -44,18 +44,13 @@ Dreams
 │                      (Your Contribution)                       │
 │                                                                │
 │  ┌──────────────────────────────────────────────────────────┐  │
-│  │  1. Location Extractor                                   │  │
+│  │  1. Location Extractor + Enrichment                      │  │
 │  │     Input: Image file                                    │  │
-│  │     Output: {lat, lon, timestamp}                        │  │ 
-│  │     Tech: Pillow EXIF parsing                            │  │
-│  └──────────────────────────────────────────────────────────┘  │
-│                              │                                 │
-│                              ▼                                 │
-│  ┌──────────────────────────────────────────────────────────┐  │
-│  │  2. Place Enrichment (Optional - Future)                 │  │
-│  │     Input: {lat, lon}                                    │  │
-│  │     Output: {place_type, name, language, cultural_tags}  │  │
-│  │     Tech: Google Places API / Nominatim                  │  │
+│  │     Output: {lat, lon, timestamp, place_category,        │  │
+│  │              display_name, location_text,                 │  │
+│  │              location_embedding (384-dim)}                │  │
+│  │     Tech: Pillow EXIF + OSM Nominatim +                  │  │
+│  │           all-MiniLM-L6-v2                                │  │
 │  └──────────────────────────────────────────────────────────┘  │
 │                              │                                 │
 │                              ▼                                 │
@@ -112,7 +107,10 @@ Dreams
 │  │  • posts: {                                               │  │
 │  │      user_id, caption, timestamp, image_path,             │  │
 │  │      sentiment: {label, score},                           │  │
-│  │      location: {lat, lon, place_type, language}           │  │
+│  │      location: {lat, lon, timestamp,                      │  │
+│  │        display_name, place_category, place_type,          │  │
+│  │        address: {road, city, state, country},             │  │
+│  │        location_text, location_embedding [384-dim]}       │  │
 │  │    }                                                      │  │
 │  │                                                           │  │
 │  │  • keywords: {                                            │  │
@@ -258,9 +256,9 @@ graph TD
 ### 1. Photo Ingestion Integration
 
 **`dreamsApp/app/ingestion/routes.py`**
-- Extract EXIF data from uploaded photos
-- Call `location_proximity.location_extractor`
-- Store location data in post schema
+- Extract EXIF GPS via `extract_gps_from_image()`
+- Enrich with reverse geocoding + semantic embedding via `enrich_location()`
+- Store enriched location data (coords + place metadata + 384-dim embedding) in post schema
 
 ### 2. Dashboard Integration
 
@@ -328,7 +326,8 @@ graph TD
 
 ### External Dependencies
 - **Image Processing**: Pillow (EXIF extraction)
-- **ML Models**: Hugging Face Transformers
+- **ML Models**: Hugging Face Transformers, sentence-transformers
+- **Geocoding**: OSM Nominatim (via requests)
 - **Geospatial**: Haversine distance calculations
 - **Clustering**: DBSCAN implementation
 

--- a/LOCATION_PROXIMITY_SUMMARY.md
+++ b/LOCATION_PROXIMITY_SUMMARY.md
@@ -13,7 +13,7 @@ A new module for DREAMS that analyzes **multi-dimensional location proximity** t
 ```
 DREAMS/location_proximity/
 ├── __init__.py
-├── location_extractor.py          # Extract GPS from images
+├── location_extractor.py          # Extract GPS + reverse geocode + semantic embedding
 ├── proximity_calculator.py        # Multi-dimensional proximity
 ├── emotion_location_mapper.py     # Emotion-location patterns
 ├── semantic_clustering.py         # Cluster similar places
@@ -131,15 +131,16 @@ for hospital in hospitals:
 
 ### Extend Post Schema
 ```python
-# Add to dreamsApp/app/ingestion/routes.py
-from location_proximity.location_extractor import extract_location_from_image
+# Already integrated in dreamsApp/app/ingestion/routes.py
+from ..utils.location_extractor import extract_gps_from_image, enrich_location
 
-location = extract_location_from_image(image_path)
-if location:
-    post_doc['location'] = {
-        'lat': location['lat'],
-        'lon': location['lon']
-    }
+gps_data = extract_gps_from_image(image_path)
+if gps_data:
+    enrichment = enrich_location(gps_data['lat'], gps_data['lon'], model=model)
+    if enrichment:
+        gps_data.update(enrichment)
+# gps_data now contains: lat, lon, timestamp, display_name,
+# place_category, place_type, address, location_text, location_embedding
 ```
 
 ### Add Dashboard Route

--- a/dreamsApp/app/ingestion/routes.py
+++ b/dreamsApp/app/ingestion/routes.py
@@ -9,7 +9,7 @@ from .  import bp
 from ..utils.sentiment import get_image_caption_and_sentiment, get_chime_category, select_text_for_analysis
 from ..utils.keywords import extract_keywords_and_vectors
 from ..utils.clustering import cluster_keywords_for_all_users
-from ..utils.location_extractor import extract_gps_from_image
+from ..utils.location_extractor import extract_gps_from_image, enrich_location
 
 from sentence_transformers import SentenceTransformer
 model = SentenceTransformer("all-MiniLM-L6-V2")
@@ -32,6 +32,10 @@ def upload_post():
 
     # Extract GPS from EXIF if available
     gps_data = extract_gps_from_image(image_path)
+    if gps_data:
+        enrichment = enrich_location(gps_data['lat'], gps_data['lon'], model=model)
+        if enrichment:
+            gps_data.update(enrichment)
     
     analysis_result = get_image_caption_and_sentiment(image_path, caption)
     

--- a/dreamsApp/app/ingestion/routes.py
+++ b/dreamsApp/app/ingestion/routes.py
@@ -1,18 +1,52 @@
-from flask import request, jsonify
-from werkzeug.utils import secure_filename
-from datetime import datetime
+import logging
 import os
-from flask import current_app
-from .  import bp
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
 
+from flask import current_app, jsonify, request
+from werkzeug.utils import secure_filename
 
-from ..utils.sentiment import get_image_caption_and_sentiment, get_chime_category, select_text_for_analysis
+from . import bp
 from ..utils.keywords import extract_keywords_and_vectors
 from ..utils.clustering import cluster_keywords_for_all_users
 from ..utils.location_extractor import extract_gps_from_image, enrich_location
+from ..utils.sentiment import (
+    get_chime_category,
+    get_image_caption_and_sentiment,
+    select_text_for_analysis,
+)
 
 from sentence_transformers import SentenceTransformer
+
+logger = logging.getLogger(__name__)
 model = SentenceTransformer("all-MiniLM-L6-V2")
+
+# Background thread pool for non-blocking location enrichment.
+# A single worker ensures Nominatim rate-limiting is respected naturally.
+_enrichment_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="loc-enrich")
+
+
+def _enrich_location_background(post_id, lat, lon, mongo_uri, db_name):
+    """Run reverse-geocoding + embedding in a background thread and
+    update the MongoDB post document with the enrichment results.
+
+    Runs outside the Flask request context, so it receives the raw
+    connection parameters instead of ``current_app.mongo``.
+    """
+    try:
+        from pymongo import MongoClient
+        client = MongoClient(mongo_uri)
+        db = client[db_name]
+
+        enrichment = enrich_location(lat, lon, model=model)
+        if enrichment:
+            db["posts"].update_one(
+                {"_id": post_id},
+                {"$set": {f"location.{k}": v for k, v in enrichment.items()}},
+            )
+            logger.info("Location enrichment complete for post %s", post_id)
+    except Exception:
+        logger.exception("Background location enrichment failed for post %s", post_id)
 
 
 @bp.route('/upload', methods=['POST'])
@@ -32,10 +66,6 @@ def upload_post():
 
     # Extract GPS from EXIF if available
     gps_data = extract_gps_from_image(image_path)
-    if gps_data:
-        enrichment = enrich_location(gps_data['lat'], gps_data['lon'], model=model)
-        if enrichment:
-            gps_data.update(enrichment)
     
     analysis_result = get_image_caption_and_sentiment(image_path, caption)
     
@@ -93,18 +123,34 @@ def upload_post():
     mongo = current_app.mongo
     insert_result = mongo['posts'].insert_one(post_doc)
 
-    if insert_result.acknowledged:
-        return jsonify({'message': 'Post created successfully',
-                        'post_id': str(insert_result.inserted_id),
-                        'user_id': user_id,
-                        'caption': caption,
-                        'timestamp': datetime.fromisoformat(timestamp),
-                        'image_path': image_path,
-                        'sentiment' : sentiment,
-                        'generated_caption': generated_caption
-                        }), 201
-    else:
+    if not insert_result.acknowledged:
         return jsonify({'error': 'Failed to create post'}), 500
+
+    # Fire-and-forget: enrich location in a background thread so the
+    # response is not blocked by Nominatim rate-limiting (~1.1 s).
+    if gps_data:
+        mongo_uri = current_app.config.get("MONGO_URI", "mongodb://localhost:27017")
+        db_name = mongo.name
+        _enrichment_executor.submit(
+            _enrich_location_background,
+            insert_result.inserted_id,
+            gps_data["lat"],
+            gps_data["lon"],
+            mongo_uri,
+            db_name,
+        )
+
+    return jsonify({
+        'message': 'Post created successfully',
+        'post_id': str(insert_result.inserted_id),
+        'user_id': user_id,
+        'caption': caption,
+        'timestamp': datetime.fromisoformat(timestamp),
+        'image_path': image_path,
+        'sentiment': sentiment,
+        'generated_caption': generated_caption,
+    }), 201
+
     
 @bp.route("/run_clustering")
 def manual_cluster():

--- a/dreamsApp/app/utils/location_extractor.py
+++ b/dreamsApp/app/utils/location_extractor.py
@@ -9,6 +9,7 @@ Pipeline:
 """
 
 import logging
+import threading
 import time
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
@@ -28,6 +29,7 @@ _NOMINATIM_USER_AGENT = (
 )
 _MIN_REQUEST_INTERVAL = 1.1  # Nominatim policy: max 1 request / second
 _CACHE_PRECISION = 5         # decimal places ≈ 1 m resolution
+_MAX_CACHE_SIZE = 10_000     # bounded LRU-style eviction (oldest first)
 
 # City-like keys Nominatim may use, in priority order
 _CITY_KEYS = ("city", "town", "village", "hamlet")
@@ -37,6 +39,7 @@ _CITY_KEYS = ("city", "town", "village", "hamlet")
 
 _geocode_cache: Dict[tuple, dict] = {}
 _last_request_time: float = 0.0
+_nominatim_lock = threading.Lock()  # protects _geocode_cache + _last_request_time
 _embedding_model = None
 
 
@@ -228,57 +231,60 @@ def reverse_geocode(lat: float, lon: float) -> Optional[Dict[str, Any]]:
         logger.warning("Invalid coordinates: lat=%s, lon=%s", lat, lon)
         return None
 
-    cache_key = (round(lat, _CACHE_PRECISION), round(lon, _CACHE_PRECISION))
-    if cache_key in _geocode_cache:
-        return _geocode_cache[cache_key]
+    with _nominatim_lock:
+        cache_key = (round(lat, _CACHE_PRECISION), round(lon, _CACHE_PRECISION))
+        if cache_key in _geocode_cache:
+            return _geocode_cache[cache_key]
 
-    _rate_limit()
+        _rate_limit()
 
-    try:
-        response = requests.get(
-            _NOMINATIM_URL,
-            params={
-                "lat": lat,
-                "lon": lon,
-                "format": "jsonv2",
-                "addressdetails": 1,
-                "accept-language": "en",
-            },
-            headers={"User-Agent": _NOMINATIM_USER_AGENT},
-            timeout=10,
-        )
-        _last_request_time = time.time()
-        response.raise_for_status()
-        data = response.json()
+        try:
+            response = requests.get(
+                _NOMINATIM_URL,
+                params={
+                    "lat": lat,
+                    "lon": lon,
+                    "format": "jsonv2",
+                    "addressdetails": 1,
+                    "accept-language": "en",
+                },
+                headers={"User-Agent": _NOMINATIM_USER_AGENT},
+                timeout=10,
+            )
+            _last_request_time = time.time()
+            response.raise_for_status()
+            data = response.json()
 
-        if "error" in data:
-            logger.warning("Nominatim error: %s", data["error"])
+            if "error" in data:
+                logger.warning("Nominatim error: %s", data["error"])
+                return None
+
+            address_raw = data.get("address", {})
+            osm_class = data.get("category", "")
+
+            result = {
+                "display_name": data.get("display_name", ""),
+                "place_category": data.get("type", ""),
+                "place_type": osm_class,
+                "osm_class": osm_class,
+                "address": {
+                    "road": address_raw.get("road"),
+                    "city": _resolve_city(address_raw),
+                    "state": address_raw.get("state"),
+                    "country": address_raw.get("country"),
+                    "country_code": address_raw.get("country_code"),
+                },
+            }
+
+            _geocode_cache[cache_key] = result
+            if len(_geocode_cache) > _MAX_CACHE_SIZE:
+                _geocode_cache.pop(next(iter(_geocode_cache)))
+            return result
+
+        except (requests.RequestException, ValueError, KeyError) as exc:
+            _last_request_time = time.time()
+            logger.error("Reverse geocoding failed for (%s, %s): %s", lat, lon, exc)
             return None
-
-        address_raw = data.get("address", {})
-        osm_class = data.get("category", "")
-
-        result = {
-            "display_name": data.get("display_name", ""),
-            "place_category": data.get("type", ""),
-            "place_type": osm_class,
-            "osm_class": osm_class,
-            "address": {
-                "road": address_raw.get("road"),
-                "city": _resolve_city(address_raw),
-                "state": address_raw.get("state"),
-                "country": address_raw.get("country"),
-                "country_code": address_raw.get("country_code"),
-            },
-        }
-
-        _geocode_cache[cache_key] = result
-        return result
-
-    except (requests.RequestException, ValueError, KeyError) as exc:
-        _last_request_time = time.time()
-        logger.error("Reverse geocoding failed for (%s, %s): %s", lat, lon, exc)
-        return None
 
 
 def format_location_text(

--- a/dreamsApp/app/utils/location_extractor.py
+++ b/dreamsApp/app/utils/location_extractor.py
@@ -1,11 +1,11 @@
 """Location extraction and semantic enrichment for DREAMS photo memories.
 
 Pipeline:
-    1. extract_gps_from_image()  — pull raw GPS + timestamp from EXIF
-    2. reverse_geocode()         — coords → place metadata via OSM Nominatim
+    1. extract_gps_from_image()  — raw GPS + timestamp from EXIF
+    2. reverse_geocode()         — coords → place metadata (OSM Nominatim)
     3. format_location_text()    — metadata → semantic text (no geography)
     4. get_location_embedding()  — text → 384-dim vector (all-MiniLM-L6-v2)
-    5. enrich_location()         — orchestrates steps 2-4 in one call
+    5. enrich_location()         — orchestrates 2-4 in one call
 """
 
 import logging
@@ -20,33 +20,29 @@ from PIL.ExifTags import GPSTAGS, TAGS
 
 logger = logging.getLogger(__name__)
 
-
 # ── Configuration ────────────────────────────────────────────────────────
 
 _NOMINATIM_URL = "https://nominatim.openstreetmap.org/reverse"
 _NOMINATIM_USER_AGENT = (
     "DREAMS-Research/1.0 (https://github.com/KathiraveluLab/DREAMS)"
 )
-_MIN_REQUEST_INTERVAL = 1.1  # Nominatim policy: max 1 request / second
-_CACHE_PRECISION = 5         # decimal places ≈ 1 m resolution
-_MAX_CACHE_SIZE = 10_000     # bounded LRU-style eviction (oldest first)
-
-# City-like keys Nominatim may use, in priority order
+_MIN_REQUEST_INTERVAL = 1.1   # Nominatim policy: max 1 req/s
+_CACHE_PRECISION = 5          # decimal places ≈ 1 m resolution
+_MAX_CACHE_SIZE = 10_000      # evict oldest entry when exceeded
 _CITY_KEYS = ("city", "town", "village", "hamlet")
-
 
 # ── Module-level state ──────────────────────────────────────────────────
 
 _geocode_cache: Dict[tuple, dict] = {}
 _last_request_time: float = 0.0
-_nominatim_lock = threading.Lock()  # protects _geocode_cache + _last_request_time
+_nominatim_lock = threading.Lock()
 _embedding_model = None
 
 
-# ── Internal helpers ─────────────────────────────────────────────────────
+# ── Helpers ──────────────────────────────────────────────────────────────
 
 def _get_embedding_model():
-    """Lazily load the SentenceTransformer singleton (avoids import-time cost)."""
+    """Lazily load the SentenceTransformer singleton."""
     global _embedding_model
     if _embedding_model is None:
         from sentence_transformers import SentenceTransformer
@@ -55,53 +51,41 @@ def _get_embedding_model():
 
 
 def _dms_to_decimal(dms_value) -> float:
-    """Convert an EXIF GPS coordinate from DMS (degrees/minutes/seconds) to
-    decimal degrees.
-
-    Each component may be a plain number or a (numerator, denominator) tuple.
-    """
+    """Convert EXIF GPS DMS (degrees/minutes/seconds) to decimal degrees."""
     if not isinstance(dms_value, (tuple, list)) or len(dms_value) != 3:
         raise ValueError(f"Expected 3-element DMS sequence, got: {dms_value}")
 
     decimal = 0.0
     for idx, component in enumerate(dms_value):
         if isinstance(component, tuple):
-            numerator, denominator = component
-            if denominator == 0:
-                raise ValueError(f"Zero denominator in DMS component: {component}")
-            value = numerator / denominator
+            if component[1] == 0:
+                raise ValueError(f"Zero denominator in DMS: {component}")
+            value = component[0] / component[1]
         else:
             value = float(component)
-        # idx 0 → degrees (÷1), idx 1 → minutes (÷60), idx 2 → seconds (÷3600)
         decimal += value / (60 ** idx)
-
     return decimal
 
 
 def _parse_gps_timestamp(gps_info: dict) -> Optional[str]:
-    """Try to build an ISO-8601 timestamp from GPSDateStamp + GPSTimeStamp."""
+    """Build ISO-8601 timestamp from GPSDateStamp + GPSTimeStamp, or None."""
     if "GPSDateStamp" not in gps_info or "GPSTimeStamp" not in gps_info:
         return None
     try:
         year, month, day = map(int, gps_info["GPSDateStamp"].split(":"))
-        hours, minutes, seconds_raw = (float(p) for p in gps_info["GPSTimeStamp"])
-
-        whole_seconds = int(seconds_raw)
-        microseconds = int((seconds_raw - whole_seconds) * 1_000_000)
-
-        dt_utc = datetime(
-            year, month, day,
-            int(hours), int(minutes), whole_seconds, microseconds,
-            tzinfo=timezone.utc,
-        )
-        return dt_utc.isoformat()
+        h, m, s_raw = (float(p) for p in gps_info["GPSTimeStamp"])
+        s_int = int(s_raw)
+        return datetime(
+            year, month, day, int(h), int(m), s_int,
+            int((s_raw - s_int) * 1_000_000), tzinfo=timezone.utc,
+        ).isoformat()
     except (ValueError, TypeError, IndexError):
         logger.warning("Could not parse GPSDateStamp / GPSTimeStamp")
         return None
 
 
 def _parse_exif_datetime(raw: str) -> Optional[str]:
-    """Parse EXIF DateTimeOriginal string into ISO-8601 (no timezone)."""
+    """Parse EXIF DateTimeOriginal to ISO-8601, or None."""
     try:
         return datetime.strptime(raw, "%Y:%m:%d %H:%M:%S").isoformat()
     except (ValueError, TypeError):
@@ -109,56 +93,13 @@ def _parse_exif_datetime(raw: str) -> Optional[str]:
         return None
 
 
-def _rate_limit() -> None:
-    """Sleep if necessary to respect Nominatim's 1-request-per-second policy."""
-    global _last_request_time
-    elapsed = time.time() - _last_request_time
-    if elapsed < _MIN_REQUEST_INTERVAL:
-        time.sleep(_MIN_REQUEST_INTERVAL - elapsed)
-
-
-def _resolve_city(address_raw: dict) -> Optional[str]:
-    """Pick the best 'city' field from a Nominatim address dict."""
-    for key in _CITY_KEYS:
-        if address_raw.get(key):
-            return address_raw[key]
-    return None
-
-
-def _resolve_place_name(geocode_result: dict) -> Optional[str]:
-    """Find the specific place name from either the address dict or the
-    display_name string.
-
-    Nominatim stores the place name under a key matching its OSM class:
-        address["amenity"] = "St. Mary's Church"
-        address["leisure"] = "Westchester Lagoon"
-    """
-    osm_class = geocode_result.get("osm_class", "")
-    address = geocode_result.get("address", {})
-
-    # Best case: keyed by OSM class
-    if osm_class and address.get(osm_class):
-        return address[osm_class]
-
-    # Fallback: first segment of display_name (usually the place itself)
-    display_name = geocode_result.get("display_name", "")
-    if display_name:
-        return display_name.split(",")[0].strip()
-
-    return None
-
-
 # ── Public API ───────────────────────────────────────────────────────────
 
 def extract_gps_from_image(image_path: str) -> Optional[Dict[str, Any]]:
-    """Extract GPS coordinates and timestamp from an image's EXIF metadata.
+    """Extract GPS coordinates and timestamp from EXIF metadata.
 
-    Args:
-        image_path: Path to the image file.
-
-    Returns:
-        ``{"lat": float, "lon": float}`` with an optional ``"timestamp"``
-        key, or ``None`` if no GPS data is available.
+    Returns ``{"lat": float, "lon": float}`` with optional ``"timestamp"``,
+    or ``None`` if no GPS data is available.
     """
     try:
         with Image.open(image_path) as img:
@@ -166,10 +107,8 @@ def extract_gps_from_image(image_path: str) -> Optional[Dict[str, Any]]:
             if not exif:
                 return None
 
-            # Scan EXIF tags for GPS block and capture timestamp
             gps_info = None
             datetime_original = None
-
             for tag_id, value in exif.items():
                 tag_name = TAGS.get(tag_id, tag_id)
                 if tag_name == "GPSInfo":
@@ -184,7 +123,6 @@ def extract_gps_from_image(image_path: str) -> Optional[Dict[str, Any]]:
             if "GPSLatitude" not in gps_info or "GPSLongitude" not in gps_info:
                 return None
 
-            # Convert DMS → decimal degrees
             lat = _dms_to_decimal(gps_info["GPSLatitude"])
             if gps_info.get("GPSLatitudeRef") == "S":
                 lat = -lat
@@ -194,14 +132,11 @@ def extract_gps_from_image(image_path: str) -> Optional[Dict[str, Any]]:
                 lon = -lon
 
             result: Dict[str, Any] = {"lat": lat, "lon": lon}
-
-            # Prefer GPS timestamp (has timezone); fall back to DateTimeOriginal
             timestamp = _parse_gps_timestamp(gps_info)
             if not timestamp and datetime_original:
                 timestamp = _parse_exif_datetime(datetime_original)
             if timestamp:
                 result["timestamp"] = timestamp
-
             return result
 
     except (AttributeError, KeyError, IndexError, TypeError, ValueError, IOError) as exc:
@@ -210,20 +145,11 @@ def extract_gps_from_image(image_path: str) -> Optional[Dict[str, Any]]:
 
 
 def reverse_geocode(lat: float, lon: float) -> Optional[Dict[str, Any]]:
-    """Reverse-geocode GPS coordinates via the OSM Nominatim API.
+    """Reverse-geocode coordinates via OSM Nominatim.
 
-    Features:
-        - In-memory cache keyed at ~1 m precision (same spot → one API call)
-        - Rate limiting (≥1.1 s between requests, per Nominatim policy)
-        - Coordinate validation (rejects out-of-range values)
-
-    Args:
-        lat: Latitude  (must be in [-90, 90]).
-        lon: Longitude (must be in [-180, 180]).
-
-    Returns:
-        Dict with keys ``display_name``, ``place_category``, ``place_type``,
-        ``address``, ``osm_class``  — or ``None`` on any failure.
+    Thread-safe, rate-limited (1.1 s), with bounded in-memory cache.
+    Returns dict with ``display_name``, ``place_category``, ``place_type``,
+    ``address`` — or ``None`` on failure.
     """
     global _last_request_time
 
@@ -236,16 +162,17 @@ def reverse_geocode(lat: float, lon: float) -> Optional[Dict[str, Any]]:
         if cache_key in _geocode_cache:
             return _geocode_cache[cache_key]
 
-        _rate_limit()
+        # Rate limit — inline to avoid extra function overhead inside lock
+        elapsed = time.time() - _last_request_time
+        if elapsed < _MIN_REQUEST_INTERVAL:
+            time.sleep(_MIN_REQUEST_INTERVAL - elapsed)
 
         try:
             response = requests.get(
                 _NOMINATIM_URL,
                 params={
-                    "lat": lat,
-                    "lon": lon,
-                    "format": "jsonv2",
-                    "addressdetails": 1,
+                    "lat": lat, "lon": lon,
+                    "format": "jsonv2", "addressdetails": 1,
                     "accept-language": "en",
                 },
                 headers={"User-Agent": _NOMINATIM_USER_AGENT},
@@ -259,20 +186,19 @@ def reverse_geocode(lat: float, lon: float) -> Optional[Dict[str, Any]]:
                 logger.warning("Nominatim error: %s", data["error"])
                 return None
 
-            address_raw = data.get("address", {})
-            osm_class = data.get("category", "")
+            addr = data.get("address", {})
+            place_type = data.get("category", "")
 
             result = {
                 "display_name": data.get("display_name", ""),
                 "place_category": data.get("type", ""),
-                "place_type": osm_class,
-                "osm_class": osm_class,
+                "place_type": place_type,
                 "address": {
-                    "road": address_raw.get("road"),
-                    "city": _resolve_city(address_raw),
-                    "state": address_raw.get("state"),
-                    "country": address_raw.get("country"),
-                    "country_code": address_raw.get("country_code"),
+                    "road": addr.get("road"),
+                    "city": next((addr[k] for k in _CITY_KEYS if addr.get(k)), None),
+                    "state": addr.get("state"),
+                    "country": addr.get("country"),
+                    "country_code": addr.get("country_code"),
                 },
             }
 
@@ -292,25 +218,12 @@ def format_location_text(
     lat: float,
     lon: float,
 ) -> str:
-    """Build a semantic location string suitable for embedding.
+    """Build a semantic location string for embedding.
 
-    Design decision: the text contains **place-type semantics only** — no
-    geographic identifiers (city, state, country).  Two churches in
-    different cities should produce similar embeddings; geography is
-    captured separately by the GEO edge in the proximity graph.
-
-    Examples:
-        ``"place of worship amenity St. Mary's Church"``
-        ``"park leisure Westchester Lagoon"``
-        ``"unknown location at coordinates 61.2181 -149.9003"``
-
-    Args:
-        geocode_result: Output of :func:`reverse_geocode`, or ``None``.
-        lat: Latitude  (used only in the fallback string).
-        lon: Longitude (used only in the fallback string).
+    Contains place-type semantics only (no city/state/country) so that
+    two churches in different cities produce similar embeddings.
     """
     fallback = f"unknown location at coordinates {lat} {lon}"
-
     if geocode_result is None:
         return fallback
 
@@ -323,65 +236,42 @@ def format_location_text(
     if place_type and place_type != category:
         parts.append(place_type)
 
-    place_name = _resolve_place_name(geocode_result)
-    if place_name:
-        parts.append(place_name)
+    # Resolve place name: try address[place_type] key, else first segment
+    # of display_name (e.g. address["amenity"] = "St. Mary's Church")
+    pt_raw = geocode_result.get("place_type", "")
+    addr = geocode_result.get("address", {})
+    if pt_raw and addr.get(pt_raw):
+        parts.append(addr[pt_raw])
+    elif geocode_result.get("display_name"):
+        parts.append(geocode_result["display_name"].split(",")[0].strip())
 
     return " ".join(parts) if parts else fallback
 
 
-def get_location_embedding(
-    location_text: str,
-    model: Any = None,
-) -> List[float]:
-    """Encode location text into a 384-dimensional semantic vector.
-
-    Args:
-        location_text: Descriptive string from :func:`format_location_text`.
-        model: Optional pre-loaded ``SentenceTransformer`` instance.
-               If ``None``, a module-level singleton is loaded lazily.
-
-    Returns:
-        List of 384 floats.
-    """
+def get_location_embedding(location_text: str, model: Any = None) -> List[float]:
+    """Encode location text into a 384-dim semantic vector."""
     if model is None:
         model = _get_embedding_model()
     return model.encode(location_text).tolist()
 
 
 def enrich_location(
-    lat: float,
-    lon: float,
-    model: Any = None,
+    lat: float, lon: float, model: Any = None,
 ) -> Dict[str, Any]:
-    """Run the full enrichment pipeline: geocode → text → embedding.
+    """Run the full pipeline: geocode → text → embedding.
 
-    Always returns a dict (never ``None``).  If geocoding fails the
-    embedding is still computed from a coordinate-based fallback string.
-
-    Args:
-        lat: Latitude.
-        lon: Longitude.
-        model: Optional pre-loaded ``SentenceTransformer``.
-
-    Returns:
-        Dict with at least ``location_text`` and ``location_embedding``.
-        On successful geocoding also includes ``display_name``,
-        ``place_category``, ``place_type``, and ``address``.
+    Always returns a dict (never None). Falls back gracefully if
+    geocoding fails.
     """
     geocode = reverse_geocode(lat, lon)
     text = format_location_text(geocode, lat, lon)
     embedding = get_location_embedding(text, model=model)
 
-    enrichment: Dict[str, Any] = {
+    result: Dict[str, Any] = {
         "location_text": text,
         "location_embedding": embedding,
     }
-
     if geocode:
-        enrichment["display_name"] = geocode["display_name"]
-        enrichment["place_category"] = geocode["place_category"]
-        enrichment["place_type"] = geocode["place_type"]
-        enrichment["address"] = geocode["address"]
-
-    return enrichment
+        for key in ("display_name", "place_category", "place_type", "address"):
+            result[key] = geocode[key]
+    return result

--- a/dreamsApp/app/utils/location_extractor.py
+++ b/dreamsApp/app/utils/location_extractor.py
@@ -1,87 +1,381 @@
-from PIL import Image
-from PIL.ExifTags import TAGS, GPSTAGS
-from datetime import datetime, timezone
-import logging
+"""Location extraction and semantic enrichment for DREAMS photo memories.
 
-def extract_gps_from_image(image_path):
+Pipeline:
+    1. extract_gps_from_image()  — pull raw GPS + timestamp from EXIF
+    2. reverse_geocode()         — coords → place metadata via OSM Nominatim
+    3. format_location_text()    — metadata → semantic text (no geography)
+    4. get_location_embedding()  — text → 384-dim vector (all-MiniLM-L6-v2)
+    5. enrich_location()         — orchestrates steps 2-4 in one call
+"""
+
+import logging
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+import requests
+from PIL import Image
+from PIL.ExifTags import GPSTAGS, TAGS
+
+logger = logging.getLogger(__name__)
+
+
+# ── Configuration ────────────────────────────────────────────────────────
+
+_NOMINATIM_URL = "https://nominatim.openstreetmap.org/reverse"
+_NOMINATIM_USER_AGENT = (
+    "DREAMS-Research/1.0 (https://github.com/KathiraveluLab/DREAMS)"
+)
+_MIN_REQUEST_INTERVAL = 1.1  # Nominatim policy: max 1 request / second
+_CACHE_PRECISION = 5         # decimal places ≈ 1 m resolution
+
+# City-like keys Nominatim may use, in priority order
+_CITY_KEYS = ("city", "town", "village", "hamlet")
+
+
+# ── Module-level state ──────────────────────────────────────────────────
+
+_geocode_cache: Dict[tuple, dict] = {}
+_last_request_time: float = 0.0
+_embedding_model = None
+
+
+# ── Internal helpers ─────────────────────────────────────────────────────
+
+def _get_embedding_model():
+    """Lazily load the SentenceTransformer singleton (avoids import-time cost)."""
+    global _embedding_model
+    if _embedding_model is None:
+        from sentence_transformers import SentenceTransformer
+        _embedding_model = SentenceTransformer("all-MiniLM-L6-V2")
+    return _embedding_model
+
+
+def _dms_to_decimal(dms_value) -> float:
+    """Convert an EXIF GPS coordinate from DMS (degrees/minutes/seconds) to
+    decimal degrees.
+
+    Each component may be a plain number or a (numerator, denominator) tuple.
+    """
+    if not isinstance(dms_value, (tuple, list)) or len(dms_value) != 3:
+        raise ValueError(f"Expected 3-element DMS sequence, got: {dms_value}")
+
+    decimal = 0.0
+    for idx, component in enumerate(dms_value):
+        if isinstance(component, tuple):
+            numerator, denominator = component
+            if denominator == 0:
+                raise ValueError(f"Zero denominator in DMS component: {component}")
+            value = numerator / denominator
+        else:
+            value = float(component)
+        # idx 0 → degrees (÷1), idx 1 → minutes (÷60), idx 2 → seconds (÷3600)
+        decimal += value / (60 ** idx)
+
+    return decimal
+
+
+def _parse_gps_timestamp(gps_info: dict) -> Optional[str]:
+    """Try to build an ISO-8601 timestamp from GPSDateStamp + GPSTimeStamp."""
+    if "GPSDateStamp" not in gps_info or "GPSTimeStamp" not in gps_info:
+        return None
     try:
-        with Image.open(image_path) as image:
-            info = image.getexif()
-            if not info:
+        year, month, day = map(int, gps_info["GPSDateStamp"].split(":"))
+        hours, minutes, seconds_raw = (float(p) for p in gps_info["GPSTimeStamp"])
+
+        whole_seconds = int(seconds_raw)
+        microseconds = int((seconds_raw - whole_seconds) * 1_000_000)
+
+        dt_utc = datetime(
+            year, month, day,
+            int(hours), int(minutes), whole_seconds, microseconds,
+            tzinfo=timezone.utc,
+        )
+        return dt_utc.isoformat()
+    except (ValueError, TypeError, IndexError):
+        logger.warning("Could not parse GPSDateStamp / GPSTimeStamp")
+        return None
+
+
+def _parse_exif_datetime(raw: str) -> Optional[str]:
+    """Parse EXIF DateTimeOriginal string into ISO-8601 (no timezone)."""
+    try:
+        return datetime.strptime(raw, "%Y:%m:%d %H:%M:%S").isoformat()
+    except (ValueError, TypeError):
+        logger.warning("Could not parse EXIF DateTimeOriginal: '%s'", raw)
+        return None
+
+
+def _rate_limit() -> None:
+    """Sleep if necessary to respect Nominatim's 1-request-per-second policy."""
+    global _last_request_time
+    elapsed = time.time() - _last_request_time
+    if elapsed < _MIN_REQUEST_INTERVAL:
+        time.sleep(_MIN_REQUEST_INTERVAL - elapsed)
+
+
+def _resolve_city(address_raw: dict) -> Optional[str]:
+    """Pick the best 'city' field from a Nominatim address dict."""
+    for key in _CITY_KEYS:
+        if address_raw.get(key):
+            return address_raw[key]
+    return None
+
+
+def _resolve_place_name(geocode_result: dict) -> Optional[str]:
+    """Find the specific place name from either the address dict or the
+    display_name string.
+
+    Nominatim stores the place name under a key matching its OSM class:
+        address["amenity"] = "St. Mary's Church"
+        address["leisure"] = "Westchester Lagoon"
+    """
+    osm_class = geocode_result.get("osm_class", "")
+    address = geocode_result.get("address", {})
+
+    # Best case: keyed by OSM class
+    if osm_class and address.get(osm_class):
+        return address[osm_class]
+
+    # Fallback: first segment of display_name (usually the place itself)
+    display_name = geocode_result.get("display_name", "")
+    if display_name:
+        return display_name.split(",")[0].strip()
+
+    return None
+
+
+# ── Public API ───────────────────────────────────────────────────────────
+
+def extract_gps_from_image(image_path: str) -> Optional[Dict[str, Any]]:
+    """Extract GPS coordinates and timestamp from an image's EXIF metadata.
+
+    Args:
+        image_path: Path to the image file.
+
+    Returns:
+        ``{"lat": float, "lon": float}`` with an optional ``"timestamp"``
+        key, or ``None`` if no GPS data is available.
+    """
+    try:
+        with Image.open(image_path) as img:
+            exif = img.getexif()
+            if not exif:
                 return None
-            
-            # Parse EXIF for GPS block
+
+            # Scan EXIF tags for GPS block and capture timestamp
             gps_info = None
             datetime_original = None
-            for tag, value in info.items():
-                decoded = TAGS.get(tag, tag)
-                if decoded == "GPSInfo":
+
+            for tag_id, value in exif.items():
+                tag_name = TAGS.get(tag_id, tag_id)
+                if tag_name == "GPSInfo":
                     gps_info = {GPSTAGS.get(t, t): value[t] for t in value}
-                elif decoded == "DateTimeOriginal":
+                elif tag_name == "DateTimeOriginal":
                     datetime_original = value
                 if gps_info is not None and datetime_original is not None:
                     break
-            
+
             if not gps_info:
                 return None
-            
             if "GPSLatitude" not in gps_info or "GPSLongitude" not in gps_info:
                 return None
-            
-            def to_degrees(val):
-                """Converts GPS coordinates from DMS to decimal degrees."""
-                if not isinstance(val, (tuple, list)) or len(val) != 3:
-                    raise ValueError(f"Invalid GPS coordinate format: {val}")
-                total_degrees = 0.0
-                for i, c in enumerate(val):
-                    if isinstance(c, tuple):
-                        if c[1] == 0:
-                            raise ValueError(f"Invalid GPS coordinate component with zero denominator: {c}")
-                        total_degrees += (c[0] / c[1]) / (60**i)
-                    else:
-                        total_degrees += float(c) / (60**i)
-                return total_degrees
-            
-            lat = to_degrees(gps_info["GPSLatitude"])
+
+            # Convert DMS → decimal degrees
+            lat = _dms_to_decimal(gps_info["GPSLatitude"])
             if gps_info.get("GPSLatitudeRef") == "S":
                 lat = -lat
-                
-            lon = to_degrees(gps_info["GPSLongitude"])
+
+            lon = _dms_to_decimal(gps_info["GPSLongitude"])
             if gps_info.get("GPSLongitudeRef") == "W":
                 lon = -lon
-            
-            result = {"lat": lat, "lon": lon}
-            
-            timestamp = None
-            if 'GPSDateStamp' in gps_info and 'GPSTimeStamp' in gps_info:
-                try:
-                    date_str = gps_info['GPSDateStamp']
-                    time_parts = gps_info['GPSTimeStamp']
-                    date_str = gps_info['GPSDateStamp']
-                    time_parts = gps_info['GPSTimeStamp']
-                    year, month, day = map(int, date_str.split(':'))
-                    h, m, s_val = [float(part) for part in time_parts]
-                    
-                    seconds = int(s_val)
-                    microseconds = int((s_val - seconds) * 1_000_000)
 
-                    # GPS time is specified in UTC
-                    dt_utc = datetime(year, month, day, int(h), int(m), seconds, microseconds, tzinfo=timezone.utc)
-                    timestamp = dt_utc.isoformat()
-                except (ValueError, TypeError, IndexError):
-                    logging.warning("Could not parse GPSDateStamp and GPSTimeStamp.")
-            
+            result: Dict[str, Any] = {"lat": lat, "lon": lon}
+
+            # Prefer GPS timestamp (has timezone); fall back to DateTimeOriginal
+            timestamp = _parse_gps_timestamp(gps_info)
             if not timestamp and datetime_original:
-                try:
-                    # EXIF DateTimeOriginal has no timezone, parse as naive and convert to ISO format
-                    timestamp = datetime.strptime(datetime_original, '%Y:%m:%d %H:%M:%S').isoformat()
-                except (ValueError, TypeError):
-                    logging.warning(f"Could not parse EXIF DateTimeOriginal: '{datetime_original}'")
-            
+                timestamp = _parse_exif_datetime(datetime_original)
             if timestamp:
                 result["timestamp"] = timestamp
+
             return result
-        
-    except (AttributeError, KeyError, IndexError, TypeError, ValueError, IOError) as e:
-        logging.error(f"Failed to extract GPS from '{image_path}': {e}")
+
+    except (AttributeError, KeyError, IndexError, TypeError, ValueError, IOError) as exc:
+        logger.error("Failed to extract GPS from '%s': %s", image_path, exc)
         return None
+
+
+def reverse_geocode(lat: float, lon: float) -> Optional[Dict[str, Any]]:
+    """Reverse-geocode GPS coordinates via the OSM Nominatim API.
+
+    Features:
+        - In-memory cache keyed at ~1 m precision (same spot → one API call)
+        - Rate limiting (≥1.1 s between requests, per Nominatim policy)
+        - Coordinate validation (rejects out-of-range values)
+
+    Args:
+        lat: Latitude  (must be in [-90, 90]).
+        lon: Longitude (must be in [-180, 180]).
+
+    Returns:
+        Dict with keys ``display_name``, ``place_category``, ``place_type``,
+        ``address``, ``osm_class``  — or ``None`` on any failure.
+    """
+    global _last_request_time
+
+    if not (-90 <= lat <= 90) or not (-180 <= lon <= 180):
+        logger.warning("Invalid coordinates: lat=%s, lon=%s", lat, lon)
+        return None
+
+    cache_key = (round(lat, _CACHE_PRECISION), round(lon, _CACHE_PRECISION))
+    if cache_key in _geocode_cache:
+        return _geocode_cache[cache_key]
+
+    _rate_limit()
+
+    try:
+        response = requests.get(
+            _NOMINATIM_URL,
+            params={
+                "lat": lat,
+                "lon": lon,
+                "format": "jsonv2",
+                "addressdetails": 1,
+                "accept-language": "en",
+            },
+            headers={"User-Agent": _NOMINATIM_USER_AGENT},
+            timeout=10,
+        )
+        _last_request_time = time.time()
+        response.raise_for_status()
+        data = response.json()
+
+        if "error" in data:
+            logger.warning("Nominatim error: %s", data["error"])
+            return None
+
+        address_raw = data.get("address", {})
+        osm_class = data.get("category", "")
+
+        result = {
+            "display_name": data.get("display_name", ""),
+            "place_category": data.get("type", ""),
+            "place_type": osm_class,
+            "osm_class": osm_class,
+            "address": {
+                "road": address_raw.get("road"),
+                "city": _resolve_city(address_raw),
+                "state": address_raw.get("state"),
+                "country": address_raw.get("country"),
+                "country_code": address_raw.get("country_code"),
+            },
+        }
+
+        _geocode_cache[cache_key] = result
+        return result
+
+    except (requests.RequestException, ValueError, KeyError) as exc:
+        _last_request_time = time.time()
+        logger.error("Reverse geocoding failed for (%s, %s): %s", lat, lon, exc)
+        return None
+
+
+def format_location_text(
+    geocode_result: Optional[Dict[str, Any]],
+    lat: float,
+    lon: float,
+) -> str:
+    """Build a semantic location string suitable for embedding.
+
+    Design decision: the text contains **place-type semantics only** — no
+    geographic identifiers (city, state, country).  Two churches in
+    different cities should produce similar embeddings; geography is
+    captured separately by the GEO edge in the proximity graph.
+
+    Examples:
+        ``"place of worship amenity St. Mary's Church"``
+        ``"park leisure Westchester Lagoon"``
+        ``"unknown location at coordinates 61.2181 -149.9003"``
+
+    Args:
+        geocode_result: Output of :func:`reverse_geocode`, or ``None``.
+        lat: Latitude  (used only in the fallback string).
+        lon: Longitude (used only in the fallback string).
+    """
+    fallback = f"unknown location at coordinates {lat} {lon}"
+
+    if geocode_result is None:
+        return fallback
+
+    category = geocode_result.get("place_category", "").replace("_", " ")
+    place_type = geocode_result.get("place_type", "").replace("_", " ")
+
+    parts: List[str] = []
+    if category:
+        parts.append(category)
+    if place_type and place_type != category:
+        parts.append(place_type)
+
+    place_name = _resolve_place_name(geocode_result)
+    if place_name:
+        parts.append(place_name)
+
+    return " ".join(parts) if parts else fallback
+
+
+def get_location_embedding(
+    location_text: str,
+    model: Any = None,
+) -> List[float]:
+    """Encode location text into a 384-dimensional semantic vector.
+
+    Args:
+        location_text: Descriptive string from :func:`format_location_text`.
+        model: Optional pre-loaded ``SentenceTransformer`` instance.
+               If ``None``, a module-level singleton is loaded lazily.
+
+    Returns:
+        List of 384 floats.
+    """
+    if model is None:
+        model = _get_embedding_model()
+    return model.encode(location_text).tolist()
+
+
+def enrich_location(
+    lat: float,
+    lon: float,
+    model: Any = None,
+) -> Dict[str, Any]:
+    """Run the full enrichment pipeline: geocode → text → embedding.
+
+    Always returns a dict (never ``None``).  If geocoding fails the
+    embedding is still computed from a coordinate-based fallback string.
+
+    Args:
+        lat: Latitude.
+        lon: Longitude.
+        model: Optional pre-loaded ``SentenceTransformer``.
+
+    Returns:
+        Dict with at least ``location_text`` and ``location_embedding``.
+        On successful geocoding also includes ``display_name``,
+        ``place_category``, ``place_type``, and ``address``.
+    """
+    geocode = reverse_geocode(lat, lon)
+    text = format_location_text(geocode, lat, lon)
+    embedding = get_location_embedding(text, model=model)
+
+    enrichment: Dict[str, Any] = {
+        "location_text": text,
+        "location_embedding": embedding,
+    }
+
+    if geocode:
+        enrichment["display_name"] = geocode["display_name"]
+        enrichment["place_category"] = geocode["place_category"]
+        enrichment["place_type"] = geocode["place_type"]
+        enrichment["address"] = geocode["address"]
+
+    return enrichment

--- a/dreamsApp/app/utils/location_extractor.py
+++ b/dreamsApp/app/utils/location_extractor.py
@@ -160,7 +160,10 @@ def reverse_geocode(lat: float, lon: float) -> Optional[Dict[str, Any]]:
     with _nominatim_lock:
         cache_key = (round(lat, _CACHE_PRECISION), round(lon, _CACHE_PRECISION))
         if cache_key in _geocode_cache:
-            return _geocode_cache[cache_key]
+            # Move item to end to implement LRU
+            value = _geocode_cache.pop(cache_key)
+            _geocode_cache[cache_key] = value
+            return value
 
         # Rate limit — inline to avoid extra function overhead inside lock
         elapsed = time.time() - _last_request_time

--- a/location_proximity/README.md
+++ b/location_proximity/README.md
@@ -84,13 +84,21 @@ This work extends these foundations by formalizing multi-dimensional proximity f
 ## Components
 
 ### `location_extractor.py`
-Extract GPS coordinates from image EXIF data.
+Extract GPS coordinates, reverse-geocode via OSM Nominatim, and generate
+a 384-dim semantic embedding (all-MiniLM-L6-v2).
 
 ```python
-from location_extractor import extract_location_from_image
+from dreamsApp.app.utils.location_extractor import extract_gps_from_image, enrich_location
 
-location = extract_location_from_image("photo.jpg")
-# Returns: {'lat': 61.2181, 'lon': -149.9003, 'timestamp': '2024:01:15 10:30:00'}
+gps = extract_gps_from_image("photo.jpg")
+# Returns: {'lat': 61.2181, 'lon': -149.9003, 'timestamp': '2024-01-15T10:30:00+00:00'}
+
+enrichment = enrich_location(gps['lat'], gps['lon'])
+# Returns: {'location_text': 'place of worship amenity St. Mary\'s Church',
+#           'location_embedding': [0.023, -0.114, ...],  # 384-dim
+#           'display_name': 'St. Mary\'s Church, Main St, Anchorage, AK',
+#           'place_category': 'place_of_worship', 'place_type': 'amenity',
+#           'address': {'road': 'Main St', 'city': 'Anchorage', ...}}
 ```
 
 ### `proximity_calculator.py`
@@ -200,29 +208,26 @@ score = composite_proximity(place1, place2, weights=weights)
 
 ## Integration with DREAMS
 
-### Extend Post Schema
+### Extend Post Schema (Implemented)
 
 ```python
 # In dreamsApp/app/ingestion/routes.py
-from location_proximity.location_extractor import extract_location_from_image
-from location_proximity.proximity_calculator import Place
+from ..utils.location_extractor import extract_gps_from_image, enrich_location
 
 @bp.route('/upload', methods=['POST'])
 def upload_post():
     # ... existing code ...
     
-    # Extract location
-    location = extract_location_from_image(image_path)
+    gps_data = extract_gps_from_image(image_path)
+    if gps_data:
+        enrichment = enrich_location(gps_data['lat'], gps_data['lon'], model=model)
+        if enrichment:
+            gps_data.update(enrichment)
     
-    if location:
-        post_doc['location'] = {
-            'lat': location['lat'],
-            'lon': location['lon'],
-            'place_type': None,  # To be enriched via API
-            'language': None
-        }
-    
-    # ... rest of code ...
+    post_doc = {
+        # ... other fields ...
+        'location': gps_data,  # includes coords + place metadata + embedding
+    }
 ```
 
 ### Add Location Analysis Route
@@ -270,7 +275,7 @@ pip install -r ../requirements.txt
 
 ## Future Enhancements
 
-- [ ] Google Places API integration for place enrichment
+- [x] Place enrichment via OSM Nominatim reverse geocoding + semantic embedding
 - [ ] Real-time location clustering as data arrives
 - [ ] Interactive map visualization (Folium)
 - [ ] Temporal-spatial pattern mining

--- a/location_proximity/RESEARCH.md
+++ b/location_proximity/RESEARCH.md
@@ -226,7 +226,7 @@ EmotionLocationEntry = {
 - Limited to documented locations (selection bias)
 
 ### 6.2 Future Directions
-1. **Automated Place Enrichment**: Google Places API integration
+1. **~~Automated Place Enrichment~~**: Implemented via OSM Nominatim reverse geocoding
 2. **Image-Based Place Recognition**: CNN for place type classification
 3. **Temporal-Spatial Modeling**: Time-series analysis of location patterns
 4. **Cross-User Analysis**: Population-level place-emotion patterns

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ pandas>=2.0.0
 scikit-learn>=1.3.0
 networkx>=3.0
 Pillow>=10.0.0
+requests>=2.31.0
 
 # Visualization
 matplotlib>=3.7.0

--- a/tests/test_location_enrichment.py
+++ b/tests/test_location_enrichment.py
@@ -1,0 +1,279 @@
+"""Tests for location enrichment functions (reverse geocoding + semantic embedding).
+
+All tests use mocks — no real API calls or model loading.
+"""
+
+import sys
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+import numpy as np
+
+# Insert utils dir so we can import location_extractor directly
+# without going through the Flask app factory chain.
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(__file__),
+        "..", "dreamsApp", "app", "utils",
+    ),
+)
+
+import location_extractor  # noqa: E402
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+SAMPLE_NOMINATIM_RESPONSE = {
+    "display_name": "St. Mary's Church, Main St, Anchorage, AK, USA",
+    "type": "place_of_worship",
+    "category": "amenity",
+    "address": {
+        "amenity": "St. Mary's Church",
+        "road": "Main Street",
+        "city": "Anchorage",
+        "state": "Alaska",
+        "country": "United States",
+        "country_code": "us",
+    },
+}
+
+PARK_NOMINATIM_RESPONSE = {
+    "display_name": "Westchester Lagoon, Spenard Rd, Anchorage, AK, USA",
+    "type": "park",
+    "category": "leisure",
+    "address": {
+        "leisure": "Westchester Lagoon",
+        "road": "Spenard Rd",
+        "city": "Anchorage",
+        "state": "Alaska",
+        "country": "United States",
+        "country_code": "us",
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """Reset module-level cache and rate-limit state between tests."""
+    location_extractor._geocode_cache.clear()
+    location_extractor._last_request_time = 0.0
+    yield
+
+
+# ── TestReverseGeocode ────────────────────────────────────────────────────
+
+
+class TestReverseGeocode:
+    """5 tests for reverse_geocode()."""
+
+    @patch("location_extractor.requests.get")
+    @patch("location_extractor.time.sleep")
+    def test_successful_geocode(self, mock_sleep, mock_get):
+        """Successful API call returns expected dict structure."""
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = SAMPLE_NOMINATIM_RESPONSE
+        mock_resp.raise_for_status.return_value = None
+        mock_get.return_value = mock_resp
+
+        result = location_extractor.reverse_geocode(61.2181, -149.9003)
+
+        assert result is not None
+        assert result["display_name"] == "St. Mary's Church, Main St, Anchorage, AK, USA"
+        assert result["place_category"] == "place_of_worship"
+        assert result["place_type"] == "amenity"
+        assert result["address"]["city"] == "Anchorage"
+        assert result["osm_class"] == "amenity"
+
+    @patch("location_extractor.requests.get")
+    @patch("location_extractor.time.sleep")
+    def test_cache_deduplication(self, mock_sleep, mock_get):
+        """Second call with same coords should hit cache, not API."""
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = SAMPLE_NOMINATIM_RESPONSE
+        mock_resp.raise_for_status.return_value = None
+        mock_get.return_value = mock_resp
+
+        result1 = location_extractor.reverse_geocode(61.2181, -149.9003)
+        result2 = location_extractor.reverse_geocode(61.2181, -149.9003)
+
+        assert result1 == result2
+        assert mock_get.call_count == 1  # only one HTTP call
+
+    def test_invalid_coordinates_returns_none(self):
+        """Out-of-range lat/lon should return None without calling API."""
+        assert location_extractor.reverse_geocode(91.0, 0.0) is None
+        assert location_extractor.reverse_geocode(0.0, 181.0) is None
+        assert location_extractor.reverse_geocode(-91.0, 0.0) is None
+
+    @patch("location_extractor.requests.get")
+    @patch("location_extractor.time.sleep")
+    def test_network_error_returns_none(self, mock_sleep, mock_get):
+        """Network failure should return None gracefully."""
+        import requests as req_lib
+        mock_get.side_effect = req_lib.ConnectionError("connection refused")
+
+        result = location_extractor.reverse_geocode(61.2181, -149.9003)
+        assert result is None
+
+    @patch("location_extractor.requests.get")
+    @patch("location_extractor.time.sleep")
+    def test_nominatim_error_returns_none(self, mock_sleep, mock_get):
+        """Nominatim error response (e.g. 'Unable to geocode') returns None."""
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"error": "Unable to geocode"}
+        mock_resp.raise_for_status.return_value = None
+        mock_get.return_value = mock_resp
+
+        result = location_extractor.reverse_geocode(61.2181, -149.9003)
+        assert result is None
+
+
+# ── TestFormatLocationText ────────────────────────────────────────────────
+
+
+class TestFormatLocationText:
+    """4 tests for format_location_text()."""
+
+    def test_full_result_has_place_type_not_geography(self):
+        """Output contains place category + type + name, NOT city/state."""
+        geocode = {
+            "display_name": "St. Mary's Church, Main St, Anchorage, AK, USA",
+            "place_category": "place_of_worship",
+            "place_type": "amenity",
+            "osm_class": "amenity",
+            "address": {
+                "amenity": "St. Mary's Church",
+                "road": "Main Street",
+                "city": "Anchorage",
+                "state": "Alaska",
+            },
+        }
+        text = location_extractor.format_location_text(geocode, 61.2181, -149.9003)
+
+        assert "place of worship" in text
+        assert "amenity" in text
+        assert "St. Mary's Church" in text
+        # Geography should NOT appear
+        assert "Anchorage" not in text
+        assert "Alaska" not in text
+
+    def test_none_fallback(self):
+        """None geocode result falls back to coordinate string."""
+        text = location_extractor.format_location_text(None, 61.2181, -149.9003)
+        assert text == "unknown location at coordinates 61.2181 -149.9003"
+
+    def test_park_with_place_name(self):
+        """Park uses leisure class key to find the place name."""
+        geocode = {
+            "display_name": "Westchester Lagoon, Spenard Rd, Anchorage, AK, USA",
+            "place_category": "park",
+            "place_type": "leisure",
+            "osm_class": "leisure",
+            "address": {
+                "leisure": "Westchester Lagoon",
+                "road": "Spenard Rd",
+            },
+        }
+        text = location_extractor.format_location_text(geocode, 61.2, -149.9)
+        assert "park" in text
+        assert "leisure" in text
+        assert "Westchester Lagoon" in text
+
+    def test_no_duplication_when_category_equals_type(self):
+        """When category and type are the same, don't repeat the word."""
+        geocode = {
+            "display_name": "Some Road, Anchorage, AK, USA",
+            "place_category": "residential",
+            "place_type": "residential",
+            "osm_class": "residential",
+            "address": {},
+        }
+        text = location_extractor.format_location_text(geocode, 61.2, -149.9)
+        # "residential" should appear exactly once
+        assert text.count("residential") == 1
+
+
+# ── TestGetLocationEmbedding ──────────────────────────────────────────────
+
+
+class TestGetLocationEmbedding:
+    """2 tests for get_location_embedding()."""
+
+    def test_returns_384_dim_list(self):
+        """Embedding should be a list of 384 floats."""
+        mock_model = MagicMock()
+        mock_model.encode.return_value = np.random.rand(384).astype(np.float32)
+
+        embedding = location_extractor.get_location_embedding(
+            "place of worship amenity St. Mary's Church",
+            model=mock_model,
+        )
+
+        assert isinstance(embedding, list)
+        assert len(embedding) == 384
+
+    def test_passes_text_to_model(self):
+        """The model.encode() should receive the exact text string."""
+        mock_model = MagicMock()
+        mock_model.encode.return_value = np.zeros(384, dtype=np.float32)
+
+        text = "hospital amenity Alaska Native Medical Center"
+        location_extractor.get_location_embedding(text, model=mock_model)
+
+        mock_model.encode.assert_called_once_with(text)
+
+
+# ── TestEnrichLocation ────────────────────────────────────────────────────
+
+
+class TestEnrichLocation:
+    """2 tests for enrich_location()."""
+
+    @patch("location_extractor.reverse_geocode")
+    def test_success_with_geocode(self, mock_geocode):
+        """Successful geocode populates all fields."""
+        mock_geocode.return_value = {
+            "display_name": "St. Mary's Church, Main St, Anchorage, AK, USA",
+            "place_category": "place_of_worship",
+            "place_type": "amenity",
+            "osm_class": "amenity",
+            "address": {
+                "amenity": "St. Mary's Church",
+                "city": "Anchorage",
+                "state": "Alaska",
+                "country": "United States",
+                "country_code": "us",
+            },
+        }
+
+        mock_model = MagicMock()
+        mock_model.encode.return_value = np.ones(384, dtype=np.float32)
+
+        result = location_extractor.enrich_location(61.2181, -149.9003, model=mock_model)
+
+        assert "location_text" in result
+        assert "location_embedding" in result
+        assert "display_name" in result
+        assert "place_category" in result
+        assert "place_type" in result
+        assert "address" in result
+        assert len(result["location_embedding"]) == 384
+
+    @patch("location_extractor.reverse_geocode")
+    def test_fallback_when_geocode_fails(self, mock_geocode):
+        """When geocoding fails, still returns text + embedding."""
+        mock_geocode.return_value = None
+
+        mock_model = MagicMock()
+        mock_model.encode.return_value = np.zeros(384, dtype=np.float32)
+
+        result = location_extractor.enrich_location(61.2181, -149.9003, model=mock_model)
+
+        assert "location_text" in result
+        assert "unknown location" in result["location_text"]
+        assert "location_embedding" in result
+        assert len(result["location_embedding"]) == 384
+        # Should NOT have geocode-specific fields
+        assert "display_name" not in result
+        assert "place_category" not in result

--- a/tests/test_location_enrichment.py
+++ b/tests/test_location_enrichment.py
@@ -82,8 +82,6 @@ class TestReverseGeocode:
         assert result["display_name"] == "St. Mary's Church, Main St, Anchorage, AK, USA"
         assert result["place_category"] == "place_of_worship"
         assert result["place_type"] == "amenity"
-        assert result["address"]["city"] == "Anchorage"
-        assert result["osm_class"] == "amenity"
 
     @patch("location_extractor.requests.get")
     @patch("location_extractor.time.sleep")
@@ -141,7 +139,6 @@ class TestFormatLocationText:
             "display_name": "St. Mary's Church, Main St, Anchorage, AK, USA",
             "place_category": "place_of_worship",
             "place_type": "amenity",
-            "osm_class": "amenity",
             "address": {
                 "amenity": "St. Mary's Church",
                 "road": "Main Street",
@@ -169,7 +166,6 @@ class TestFormatLocationText:
             "display_name": "Westchester Lagoon, Spenard Rd, Anchorage, AK, USA",
             "place_category": "park",
             "place_type": "leisure",
-            "osm_class": "leisure",
             "address": {
                 "leisure": "Westchester Lagoon",
                 "road": "Spenard Rd",
@@ -186,7 +182,6 @@ class TestFormatLocationText:
             "display_name": "Some Road, Anchorage, AK, USA",
             "place_category": "residential",
             "place_type": "residential",
-            "osm_class": "residential",
             "address": {},
         }
         text = location_extractor.format_location_text(geocode, 61.2, -149.9)
@@ -237,7 +232,6 @@ class TestEnrichLocation:
             "display_name": "St. Mary's Church, Main St, Anchorage, AK, USA",
             "place_category": "place_of_worship",
             "place_type": "amenity",
-            "osm_class": "amenity",
             "address": {
                 "amenity": "St. Mary's Church",
                 "city": "Anchorage",


### PR DESCRIPTION
Implementation of reverse Geocoding with OpenStreetMap Nominatim.

```
extract_gps_from_image() → {lat, lon}
                              ↓
reverse_geocode()         → place_category, display_name, address  (OSM Nominatim)
format_location_text()    → "place of worship amenity St. Mary's Church"  (no geography)
get_location_embedding()  → 384-dim vector  (all-MiniLM-L6-v2)
```
MongoDB post location now includes
```
{
  "lat": 61.2181, "lon": -149.9003, "timestamp": "...",
  "display_name": "St. Mary's Church, Main St, Anchorage, AK",
  "place_category": "place_of_worship",
  "place_type": "amenity",
  "address": {"road": "Main St", "city": "Anchorage", "state": "Alaska", ...},
  "location_text": "place of worship amenity St. Mary's Church",
  "location_embedding": [0.023, -0.114, ...]
}
```
Semantic text excludes geography that is handled by a different layer.