### PR TITLE
fix: correct EmotionTimeline constructor call in segment_timeline_fixed_windows()

### DIFF
--- a/dreamsApp/analytics/emotion_segmentation.py
+++ b/dreamsApp/analytics/emotion_segmentation.py
@@ -139,7 +139,7 @@ def segment_timeline_fixed_windows(
         ]
         
         # Create new EmotionTimeline for this segment
-        segment_timeline = EmotionTimeline(events_in_window)
+        segment_timeline = EmotionTimeline(subject_id=timeline.subject_id, events=tuple(events_in_window))
         
         segments.append((window, segment_timeline))
     


### PR DESCRIPTION
Fixes #107

## What
Fixed incorrect `EmotionTimeline` constructor call in `segment_timeline_fixed_windows()` that caused a runtime crash.

---

## Change
```diff
- segment_timeline = EmotionTimeline(events_in_window)
+ segment_timeline = EmotionTimeline(subject_id=timeline.subject_id, events=tuple(events_in_window))
```

## Why

`EmotionTimeline` is a frozen dataclass expecting `subject_id: str` as its first argument. The old code passed `events_in_window` (a list) as `subject_id`, causing a type mismatch crash. The fix uses explicit keyword arguments to correctly pass `subject_id` from the input timeline and convert events to a tuple.

---

## Testing

Verified with a test script — creates a timeline with 3 events, segments into 2-hour windows, and confirms:

-  2 segments created correctly
- `subject_id` preserved as `'test_user'` across all segments
- Events correctly distributed across windows