### PR TITLE
fix: prevent image file overwrites by adding UUID prefix to uploaded filenames

### DIFF
--- a/dreamsApp/app/ingestion/routes.py
+++ b/dreamsApp/app/ingestion/routes.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import uuid
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 
@@ -87,8 +88,9 @@ def upload_post():
         return jsonify({'error': 'Missing required fields'}), 400
     
     filename = secure_filename(image.filename)
+    unique_filename = f"{uuid.uuid4().hex}_{filename}"
     upload_path = current_app.config['UPLOAD_FOLDER']
-    image_path = os.path.join(upload_path, filename)
+    image_path = os.path.join(upload_path, unique_filename)
     image.save(image_path)
 
     # Extract GPS from EXIF if available


### PR DESCRIPTION
Fixes #112 

## What
Added a UUID prefix to uploaded filenames to guarantee uniqueness and prevent silent file overwrites.

---

## Change
```diff
 import logging
 import os
+import uuid

 filename = secure_filename(image.filename)
+unique_filename = f"{uuid.uuid4().hex}_{filename}"
 upload_path = current_app.config['UPLOAD_FOLDER']
-image_path = os.path.join(upload_path, filename)
+image_path = os.path.join(upload_path, unique_filename)
 image.save(image_path)
```

## Why

`secure_filename()` sanitizes but does not make filenames unique. Two uploads of `photo.jpg` would silently overwrite each other, corrupting the first post's image data. The UUID prefix (e.g., `a1b2c3d4e5f6_photo.jpg`) guarantees uniqueness while preserving the original filename for readability.