### PR TITLE
Add Places365 Background Scene Classifier to DREAMS Pipeline

### DIFF
--- a/analytics_server.py
+++ b/analytics_server.py
@@ -43,7 +43,7 @@ try:
 except ImportError as e:
     _PERCEPTUAL_DEPS_AVAILABLE = False
     _PERCEPTUAL_DEPS_ERROR = str(e)
-    print(f"⚠️  WARNING: Perceptual emotion analysis dependencies not available: {e}")
+    print(f"WARNING: Perceptual emotion analysis dependencies not available: {e}")
     print("   The /api/perceptual-emotion and /api/compare-images endpoints will return fallback data.")
 
 # Check for text sentiment analysis dependencies
@@ -54,7 +54,7 @@ try:
 except ImportError as e:
     _TEXT_SENTIMENT_AVAILABLE = False
     _TEXT_SENTIMENT_ERROR = str(e)
-    print(f"⚠️  WARNING: Text sentiment analysis not available: {e}")
+    print(f"WARNING: Text sentiment analysis not available: {e}")
 
 # Simulated users with emotion data
 SAMPLE_USERS = {
@@ -85,7 +85,7 @@ try:
         BOB_SMITH_CAPTIONS[img_path] = photo.get("description", "")
     print(f"✅ Loaded bob-smith sample data: {len(BOB_SMITH_IMAGES)} images")
 except (FileNotFoundError, json.JSONDecodeError) as e:
-    print(f"⚠️  Could not load or parse bob-smith.json: {e}")
+    print(f"Could not load or parse bob-smith.json: {e}")
 
 def generate_sample_posts(user_id: str) -> list:
     """Generate sample posts with emotions for a user."""
@@ -198,7 +198,7 @@ MAIN_TEMPLATE = """
 </head>
 <body>
     <div class="container py-5">
-        <h1 class="text-center mb-4">📊 DREAMS Analytics Demo</h1>
+        <h1 class="text-center mb-4">DREAMS Analytics Demo</h1>
         
         <div class="row justify-content-center">
             {% for user_id, name in users.items() %}
@@ -207,7 +207,7 @@ MAIN_TEMPLATE = """
                     <h5 class="text-white">{{ name }}</h5>
                     <p class="text-white small">{{ user_id }}</p>
                     <div class="d-grid gap-2">
-                        <a href="{{ url_for('narrative_view', user_id=user_id) }}" class="btn btn-narrative text-white">📊 View Narrative</a>
+                        <a href="{{ url_for('narrative_view', user_id=user_id) }}" class="btn btn-narrative text-white">View Narrative</a>
                         <a href="{{ url_for('api_timeline', user_id=user_id) }}" class="btn btn-outline-secondary btn-sm">API: Timeline</a>
                         <a href="{{ url_for('api_frontend_payload', user_id=user_id) }}" class="btn btn-outline-secondary btn-sm">API: Frontend Payload</a>
                     </div>
@@ -299,7 +299,7 @@ NARRATIVE_TEMPLATE = """
 <body>
     <div class="container py-4">
         <div class="d-flex justify-content-between align-items-center mb-4">
-            <h2>📊 Temporal Narrative: {{ user_id }}</h2>
+            <h2>Temporal Narrative: {{ user_id }}</h2>
             <a href="/" class="btn btn-back text-white">← Back</a>
         </div>
 
@@ -362,19 +362,19 @@ NARRATIVE_TEMPLATE = """
             <div class="prob-section-title">Emotion Analysis <span class="perceptual-badge" id="modal-badge">🔬 PERCEPTUAL</span></div>
             <div id="prob-display">
                 <div class="prob-row">
-                    <span class="prob-label" style="color: #4ad974;">😊 Happy</span>
+                    <span class="prob-label" style="color: #4ad974;">Happy</span>
                     <div class="prob-bar-container">
                         <div id="prob-bar-positive" class="prob-bar prob-positive" style="width: 0%;">0%</div>
                     </div>
                 </div>
                 <div class="prob-row">
-                    <span class="prob-label" style="color: #4a90d9;">😐 Neutral</span>
+                    <span class="prob-label" style="color: #4a90d9;">Neutral</span>
                     <div class="prob-bar-container">
                         <div id="prob-bar-neutral" class="prob-bar prob-neutral" style="width: 0%;">0%</div>
                     </div>
                 </div>
                 <div class="prob-row">
-                    <span class="prob-label" style="color: #d94a4a;">😢 Sad</span>
+                    <span class="prob-label" style="color: #d94a4a;">Sad</span>
                     <div class="prob-bar-container">
                         <div id="prob-bar-negative" class="prob-bar prob-negative" style="width: 0%;">0%</div>
                     </div>
@@ -384,7 +384,7 @@ NARRATIVE_TEMPLATE = """
             <div id="notes-text" class="small text-muted mt-2"></div>
             
             <div class="disclaimer">
-                ⚠️ This is a probabilistic estimate. No confidence is ever 100%.
+                Note: This is a probabilistic estimate. No confidence is ever 100%.
             </div>
         </div>
     </div>
@@ -730,7 +730,7 @@ NARRATIVE_TEMPLATE = """
                     labels: labels,
                     datasets: [
                         {
-                            label: '😊 Happy',
+                            label: 'Happy',
                             data: emotionGraphData.map(d => d.happy),
                             backgroundColor: 'rgba(74, 217, 116, 0.85)',
                             borderColor: '#4ad974',
@@ -738,7 +738,7 @@ NARRATIVE_TEMPLATE = """
                             borderRadius: 4,
                         },
                         {
-                            label: '😐 Neutral',
+                            label: 'Neutral',
                             data: emotionGraphData.map(d => d.neutral),
                             backgroundColor: 'rgba(74, 144, 217, 0.85)',
                             borderColor: '#4a90d9',
@@ -746,7 +746,7 @@ NARRATIVE_TEMPLATE = """
                             borderRadius: 4,
                         },
                         {
-                            label: '😢 Sad',
+                            label: 'Sad',
                             data: emotionGraphData.map(d => d.sad),
                             backgroundColor: 'rgba(217, 74, 74, 0.85)',
                             borderColor: '#d94a4a',

--- a/data_integrity/reporter.py
+++ b/data_integrity/reporter.py
@@ -88,7 +88,7 @@ class ValidationReport:
         ]
         
         for issue in self.issues:
-            icon = "✗" if issue.severity == Severity.ERROR else "⚠" if issue.severity == Severity.WARNING else "ℹ"
+            icon = "X" if issue.severity == Severity.ERROR else "!" if issue.severity == Severity.WARNING else "i"
             location_str = f" [{issue.location}]" if issue.location else ""
             lines.append(f"\n{icon} {issue.severity.value} ({issue.category}){location_str}")
             lines.append(f"  {issue.message}")

--- a/dream-integration/script.py
+++ b/dream-integration/script.py
@@ -115,7 +115,7 @@ def migrate():
                 if not os.path.isdir(a_dir):
                     continue
 
-                print(f"    📊 Migrating analysis from {a_dir}")
+                print(f"    Migrating analysis from {a_dir}")
 
                 text_scores = {}
                 image_scores = {}

--- a/dreamsApp/app/__init__.py
+++ b/dreamsApp/app/__init__.py
@@ -32,6 +32,9 @@ def create_app(test_config=None):
     client = MongoClient(app.config["MONGO_URI"])
     app.mongo = client[app.config["MONGO_DB_NAME"]]
 
+    # Indexes for query performance
+    app.mongo['posts'].create_index('scene_type')
+
     
     login_manager = LoginManager()
     login_manager.init_app(app)

--- a/dreamsApp/app/ingestion/routes.py
+++ b/dreamsApp/app/ingestion/routes.py
@@ -2,13 +2,17 @@ from flask import request, jsonify
 from werkzeug.utils import secure_filename
 from datetime import datetime
 import os
+import logging
 from flask import current_app
 from .  import bp
+
+logger = logging.getLogger(__name__)
 
 
 from ..utils.sentiment import get_image_caption_and_sentiment, get_chime_category, select_text_for_analysis
 from ..utils.keywords import extract_keywords_and_vectors
 from ..utils.clustering import cluster_keywords_for_all_users
+from ..utils.places365_classifier import classify_scene
 
 from sentence_transformers import SentenceTransformer
 model = SentenceTransformer("all-MiniLM-L6-V2")
@@ -71,6 +75,19 @@ def upload_post():
             )
     
 
+    # Scene classification — Basic integration
+    # Fine-tuning on Alaska imagery and CLIP secondary verification planned for GSoC coding period
+    try:
+        scene_result = classify_scene(image_path)
+        scene_type = scene_result.get("scene_type", "unknown")
+        scene_confidence = scene_result.get("scene_confidence", 0.0)
+        scene_raw_top3 = scene_result.get("scene_raw_top3", [])
+    except Exception as e:
+        logger.warning(f"Scene classification failed for {image_path}: {e}")
+        scene_type = "unknown"
+        scene_confidence = 0.0
+        scene_raw_top3 = []
+
     post_doc = {
         'user_id': user_id,
         'caption': caption,
@@ -78,7 +95,10 @@ def upload_post():
         'image_path': image_path,
         'generated_caption': generated_caption,
         'sentiment' : sentiment,
-        'chime_analysis': chime_result  # Store the new object
+        'chime_analysis': chime_result,  # Store the new object
+        'scene_type': scene_type,
+        'scene_confidence': scene_confidence,
+        'scene_raw_top3': scene_raw_top3,
     }
 
     mongo = current_app.mongo

--- a/dreamsApp/app/templates/dashboard/narrative.html
+++ b/dreamsApp/app/templates/dashboard/narrative.html
@@ -176,7 +176,7 @@
 
     <!-- Header -->
     <section class="section text-center">
-        <h2 class="section-title">📊 Temporal Narrative Analysis</h2>
+        <h2 class="section-title">Temporal Narrative Analysis</h2>
         <p class="section-description">
             Explore emotional episodes and their relationships over time for user: <strong>{{ user_id }}</strong>
         </p>
@@ -238,8 +238,8 @@
 
     <!-- Controls -->
     <section class="section text-center">
-        <button class="btn-refresh" onclick="refreshData()">🔄 Refresh Analysis</button>
-        <button class="btn-refresh" onclick="invalidateCache()" style="background: linear-gradient(135deg, #d94a4a 0%, #bd3535 100%);">🗑️ Clear Cache</button>
+        <button class="btn-refresh" onclick="refreshData()">Refresh Analysis</button>
+        <button class="btn-refresh" onclick="invalidateCache()" style="background: linear-gradient(135deg, #d94a4a 0%, #bd3535 100%);">Clear Cache</button>
     </section>
 
 </div>
@@ -270,7 +270,7 @@
 
             document.getElementById('stat-episodes').textContent = payload.node_count;
             document.getElementById('stat-edges').textContent = payload.edge_count;
-            document.getElementById('stat-cached').textContent = '✓';
+            document.getElementById('stat-cached').textContent = 'Yes';
             document.getElementById('graph-fingerprint').textContent = `Graph ID: ${payload.graph_id}`;
 
             // Render graph

--- a/dreamsApp/app/utils/places365_classifier.py
+++ b/dreamsApp/app/utils/places365_classifier.py
@@ -1,0 +1,261 @@
+# Basic integration — fine-tuning on Alaska imagery and CLIP secondary verification planned for GSoC coding period
+
+"""
+Places365 Scene Classification for DREAMS
+
+Classifies images into recovery-relevant scene categories using the
+Places365 ResNet50 pretrained model. Scene types are mapped from
+365 raw place categories into 6 DREAMS-specific categories.
+"""
+
+import os
+import logging
+import torch
+import numpy as np
+from PIL import Image
+from torchvision import transforms
+
+logger = logging.getLogger(__name__)
+
+# Module-level cache for model and labels
+_model = None
+_labels = None
+
+# The 6 DREAMS scene categories
+VALID_SCENE_TYPES = {
+    "clinical_or_institutional",
+    "faith_community",
+    "recovery_support",
+    "residential_or_transitional",
+    "shelter_or_dropin",
+    "outdoor_or_wilderness",
+}
+
+# Mapping from raw Places365 labels to DREAMS categories.
+# Labels not present here will not contribute to any category.
+CATEGORY_MAPPING = {
+    # clinical_or_institutional
+    "hospital": "clinical_or_institutional",
+    "hospital_room": "clinical_or_institutional",
+    "clinic": "clinical_or_institutional",
+    "pharmacy": "clinical_or_institutional",
+    "dentists_office": "clinical_or_institutional",
+    "operating_room": "clinical_or_institutional",
+    "waiting_room": "clinical_or_institutional",
+    "laboratory": "clinical_or_institutional",
+    "nursing_home": "clinical_or_institutional",
+
+    # faith_community
+    "church/indoor": "faith_community",
+    "church/outdoor": "faith_community",
+    "mosque/indoor": "faith_community",
+    "mosque/outdoor": "faith_community",
+    "temple/east_asia": "faith_community",
+    "temple/south_asia": "faith_community",
+    "synagogue/indoor": "faith_community",
+    "chapel": "faith_community",
+    "cathedral/indoor": "faith_community",
+    "cathedral/outdoor": "faith_community",
+    "abbey": "faith_community",
+
+    # recovery_support
+    "community_center": "recovery_support",
+    "recreation_room": "recovery_support",
+    "conference_room": "recovery_support",
+    "meeting_room": "recovery_support",
+    "classroom": "recovery_support",
+    "lecture_room": "recovery_support",
+    "office": "recovery_support",
+    "gym/indoor": "recovery_support",
+
+    # residential_or_transitional
+    "bedroom": "residential_or_transitional",
+    "living_room": "residential_or_transitional",
+    "house": "residential_or_transitional",
+    "apartment_building/outdoor": "residential_or_transitional",
+    "kitchen": "residential_or_transitional",
+    "dining_room": "residential_or_transitional",
+    "bathroom": "residential_or_transitional",
+    "home_office": "residential_or_transitional",
+    "porch": "residential_or_transitional",
+    "yard": "residential_or_transitional",
+    "balcony/interior": "residential_or_transitional",
+    "balcony/exterior": "residential_or_transitional",
+    "garage/indoor": "residential_or_transitional",
+    "residential_neighborhood": "residential_or_transitional",
+
+    # shelter_or_dropin
+    "tent/outdoor": "shelter_or_dropin",
+    "dormitory": "shelter_or_dropin",
+    "youth_hostel": "shelter_or_dropin",
+    "motel": "shelter_or_dropin",
+    "locker_room": "shelter_or_dropin",
+    "campsite": "shelter_or_dropin",
+
+    # outdoor_or_wilderness
+    "park": "outdoor_or_wilderness",
+    "forest_path": "outdoor_or_wilderness",
+    "forest/broadleaf": "outdoor_or_wilderness",
+    "forest/needleleaf": "outdoor_or_wilderness",
+    "mountain": "outdoor_or_wilderness",
+    "mountain_path": "outdoor_or_wilderness",
+    "mountain_snowy": "outdoor_or_wilderness",
+    "field/cultivated": "outdoor_or_wilderness",
+    "field/wild": "outdoor_or_wilderness",
+    "lake/natural": "outdoor_or_wilderness",
+    "river": "outdoor_or_wilderness",
+    "ocean": "outdoor_or_wilderness",
+    "beach": "outdoor_or_wilderness",
+    "creek": "outdoor_or_wilderness",
+    "sky": "outdoor_or_wilderness",
+    "valley": "outdoor_or_wilderness",
+    "snowfield": "outdoor_or_wilderness",
+    "glacier": "outdoor_or_wilderness",
+    "trail": "outdoor_or_wilderness",
+    "swamp": "outdoor_or_wilderness",
+    "waterfall": "outdoor_or_wilderness",
+}
+
+
+# Image preprocessing: resize to 256, center crop to 224, normalize with ImageNet stats
+preprocess = transforms.Compose([
+    transforms.Resize(256),
+    transforms.CenterCrop(224),
+    transforms.ToTensor(),
+    transforms.Normalize(
+        mean=[0.485, 0.456, 0.406],
+        std=[0.229, 0.224, 0.225]
+    ),
+])
+
+
+def _load_model():
+    """
+    Load the Places365 ResNet50 model and category labels.
+
+    Downloads the pretrained weights from the Places365 project and
+    the category label file on first call, then caches them at module
+    level for subsequent calls.
+
+    Returns:
+        tuple: (model, labels) where model is the ResNet50 with Places365
+               weights and labels is a list of 365 scene category strings.
+    """
+    global _model, _labels
+
+    if _model is not None and _labels is not None:
+        return _model, _labels
+
+    logger.info("Loading Places365 ResNet50 model...")
+
+    # Use the Places365 pretrained ResNet50
+    model_file = "resnet50_places365.pth.tar"
+    model_url = "http://places2.csail.mit.edu/models_places365/" + model_file
+
+    # Download model weights if not cached
+    cache_dir = os.path.join(torch.hub.get_dir(), "places365")
+    os.makedirs(cache_dir, exist_ok=True)
+    model_path = os.path.join(cache_dir, model_file)
+
+    if not os.path.exists(model_path):
+        logger.info("Downloading Places365 weights...")
+        torch.hub.download_url_to_file(model_url, model_path)
+
+    # Build ResNet50 architecture with 365 output classes
+    from torchvision.models import resnet50
+    model = resnet50(num_classes=365)
+    checkpoint = torch.load(model_path, map_location="cpu", weights_only=False)
+    state_dict = {k.replace("module.", ""): v for k, v in checkpoint["state_dict"].items()}
+    model.load_state_dict(state_dict)
+    model.eval()
+
+    # Download category labels
+    labels_file = "categories_places365.txt"
+    labels_url = "https://raw.githubusercontent.com/csailvision/places365/master/" + labels_file
+    labels_path = os.path.join(cache_dir, labels_file)
+
+    if not os.path.exists(labels_path):
+        logger.info("Downloading Places365 labels...")
+        torch.hub.download_url_to_file(labels_url, labels_path)
+
+    labels = []
+    with open(labels_path, "r") as f:
+        for line in f:
+            # Format: /a/airfield 0  or  /c/church/indoor 0
+            # Split on "/" and rejoin everything after the prefix letter
+            label = line.strip().split(" ")[0]
+            label = "/".join(label.split("/")[2:])
+            labels.append(label)
+
+    _model = model
+    _labels = labels
+    logger.info("Places365 model loaded successfully.")
+    return _model, _labels
+
+
+def classify_scene(image_path):
+    """
+    Classify the scene type of an image using Places365 ResNet50.
+
+    Takes an image file path, runs it through the pretrained Places365
+    model, and maps the top prediction to one of 6 DREAMS recovery
+    categories. If the model's confidence is below 0.4, returns
+    "unknown" as the scene type.
+
+    Args:
+        image_path (str): Absolute or relative path to the image file.
+
+    Returns:
+        dict: A dictionary with the following keys:
+            - scene_type (str): One of the 6 DREAMS categories or "unknown".
+            - scene_confidence (float): Confidence score between 0 and 1.
+            - scene_raw_top3 (list): Top 3 raw Places365 labels with
+              their confidence scores, each as
+              {"label": str, "confidence": float}.
+    """
+    model, labels = _load_model()
+
+    # Load and preprocess the image
+    img = Image.open(image_path).convert("RGB")
+    input_tensor = preprocess(img).unsqueeze(0)  # add batch dimension
+
+    # Run inference
+    with torch.no_grad():
+        output = model(input_tensor)
+        probabilities = torch.nn.functional.softmax(output[0], dim=0)
+
+    # Get top 3 predictions
+    top3_prob, top3_idx = torch.topk(probabilities, 3)
+    scene_raw_top3 = []
+    for i in range(3):
+        scene_raw_top3.append({
+            "label": labels[top3_idx[i].item()],
+            "confidence": round(float(top3_prob[i].item()), 4),
+        })
+
+    # Determine DREAMS scene category from top predictions
+    # Walk through top predictions and use the first one that maps
+    scene_type = "unknown"
+    scene_confidence = round(float(top3_prob[0].item()), 4)
+
+    # Check confidence threshold
+    if scene_confidence < 0.4:
+        return {
+            "scene_type": "unknown",
+            "scene_confidence": scene_confidence,
+            "scene_raw_top3": scene_raw_top3,
+        }
+
+    # Try to map top predictions to a DREAMS category
+    for i in range(3):
+        raw_label = labels[top3_idx[i].item()]
+        if raw_label in CATEGORY_MAPPING:
+            scene_type = CATEGORY_MAPPING[raw_label]
+            scene_confidence = round(float(top3_prob[i].item()), 4)
+            break
+
+    return {
+        "scene_type": scene_type,
+        "scene_confidence": scene_confidence,
+        "scene_raw_top3": scene_raw_top3,
+    }

--- a/dreamsApp/app/utils/places365_classifier.py
+++ b/dreamsApp/app/utils/places365_classifier.py
@@ -164,7 +164,7 @@ def _load_model():
     # Build ResNet50 architecture with 365 output classes
     from torchvision.models import resnet50
     model = resnet50(num_classes=365)
-    checkpoint = torch.load(model_path, map_location="cpu", weights_only=False)
+    checkpoint = torch.load(model_path, map_location="cpu", weights_only=True)
     state_dict = {k.replace("module.", ""): v for k, v in checkpoint["state_dict"].items()}
     model.load_state_dict(state_dict)
     model.eval()

--- a/dreamsApp/app/utils/places365_classifier.py
+++ b/dreamsApp/app/utils/places365_classifier.py
@@ -150,7 +150,7 @@ def _load_model():
 
     # Use the Places365 pretrained ResNet50
     model_file = "resnet50_places365.pth.tar"
-    model_url = "http://places2.csail.mit.edu/models_places365/" + model_file
+    model_url = "https://places2.csail.mit.edu/models_places365/" + model_file
 
     # Download model weights if not cached
     cache_dir = os.path.join(torch.hub.get_dir(), "places365")

--- a/ml/text_sentiment.py
+++ b/ml/text_sentiment.py
@@ -86,7 +86,7 @@ def _load_pipeline():
         return _sentiment_pipeline
     except Exception as e:
         _pipeline_error = str(e)
-        print(f"⚠️  Text sentiment pipeline not available: {e}. Using keyword fallback.")
+        print(f"WARNING: Text sentiment pipeline not available: {e}. Using keyword fallback.")
         return None
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ flake8>=6.0.0
 
 # NLP / ML
 torch
+torchvision
 transformers>=4.40.0
 datasets>=2.19.0
 sentence-transformers>=2.6.0

--- a/sample-data/bob-smith/bob-smith.json
+++ b/sample-data/bob-smith/bob-smith.json
@@ -14,7 +14,7 @@
     {
       "filename": "happy.jpg",
       "category": "happy",
-      "description": "The flip side. It's amazing what good coffee and even better company can do for the soul. Definitely needed these laughs after this week. Feeling much lighter. ☕😊 #goodvibes #coffeetime #grateful"
+      "description": "The flip side. It's amazing what good coffee and even better company can do for the soul. Definitely needed these laughs after this week. Feeling much lighter. #goodvibes #coffeetime #grateful"
     }
   ]
 }

--- a/tests/test_places365_classifier.py
+++ b/tests/test_places365_classifier.py
@@ -1,0 +1,185 @@
+"""
+Tests for Places365 scene classification module.
+
+Uses mocked model outputs so tests run without downloading the
+Places365 weights (~100 MB). Run with:
+    python -m pytest tests/test_places365_classifier.py -v -s
+"""
+
+import pytest
+import os
+import sys
+import numpy as np
+from unittest.mock import patch, MagicMock
+from PIL import Image
+import tempfile
+import torch
+
+# Import the classifier directly to avoid triggering the full Flask app init
+# chain (which requires flask_login, MongoDB, etc.)
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "dreamsApp", "app", "utils"))
+import places365_classifier  # noqa: E402
+
+
+# --- Fixtures ---
+
+@pytest.fixture
+def sample_image_path():
+    """Create a temporary test image and return its path."""
+    with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as f:
+        img = Image.fromarray(np.random.randint(0, 255, (256, 256, 3), dtype=np.uint8))
+        img.save(f, format="JPEG")
+        yield f.name
+    os.unlink(f.name)
+
+
+def _make_mock_output(top_label_index, confidence, labels_list):
+    """
+    Build a fake model output tensor where `top_label_index` gets
+    `confidence` and the rest is spread uniformly.
+
+    Args:
+        top_label_index: Index of the label that should have highest confidence.
+        confidence: Desired softmax probability for the top label.
+        labels_list: Full list of label strings (length 365).
+
+    Returns:
+        torch.Tensor: A 1x365 logit tensor whose softmax peaks at top_label_index.
+    """
+    n = len(labels_list)
+    # Start with uniform small logits
+    logits = torch.zeros(1, n)
+    # Set one logit high enough to dominate after softmax
+    logits[0, top_label_index] = 10.0 if confidence >= 0.4 else 1.0
+    return logits
+
+
+def _build_mock_labels():
+    """Build a list of 365 fake labels, including several known DREAMS-mapped ones."""
+    labels = [f"unlabeled_scene_{i}" for i in range(365)]
+    # Place known labels at specific indices for testing
+    labels[0] = "hospital_room"         # clinical_or_institutional
+    labels[1] = "church/indoor"         # faith_community
+    labels[2] = "park"                  # outdoor_or_wilderness
+    labels[3] = "bedroom"              # residential_or_transitional
+    labels[4] = "dormitory"            # shelter_or_dropin
+    labels[5] = "community_center"     # recovery_support
+    return labels
+
+
+MOCK_LABELS = _build_mock_labels()
+
+
+# --- Test Cases ---
+
+@pytest.mark.parametrize("top_idx,expected_scene_type", [
+    (0, "clinical_or_institutional"),   # hospital_room
+    (1, "faith_community"),             # church/indoor
+    (2, "outdoor_or_wilderness"),       # park
+    (3, "residential_or_transitional"), # bedroom
+    (4, "shelter_or_dropin"),           # dormitory
+    (5, "recovery_support"),            # community_center
+])
+def test_classify_scene_categories(sample_image_path, top_idx, expected_scene_type):
+    """
+    Test that classify_scene correctly maps raw Places365 labels to
+    DREAMS categories when confidence is above threshold.
+    """
+    mock_model = MagicMock()
+    mock_output = _make_mock_output(top_idx, 0.9, MOCK_LABELS)
+    mock_model.return_value = mock_output
+
+    with patch.object(places365_classifier, "_load_model") as mock_load:
+        mock_load.return_value = (mock_model, MOCK_LABELS)
+        result = places365_classifier.classify_scene(sample_image_path)
+
+    print(f"\n  Top label index: {top_idx}")
+    print(f"  Result: {result}")
+
+    assert result["scene_type"] == expected_scene_type
+    assert result["scene_type"] in places365_classifier.VALID_SCENE_TYPES
+    assert 0 <= result["scene_confidence"] <= 1
+    assert len(result["scene_raw_top3"]) == 3
+
+
+def test_classify_scene_low_confidence_returns_unknown(sample_image_path):
+    """
+    Test that classify_scene returns 'unknown' when the model's
+    top confidence is below the 0.4 threshold.
+    """
+    mock_model = MagicMock()
+    # All logits near zero → softmax spreads probability → max < 0.4
+    mock_output = torch.zeros(1, 365)
+    mock_model.return_value = mock_output
+
+    with patch.object(places365_classifier, "_load_model") as mock_load:
+        mock_load.return_value = (mock_model, MOCK_LABELS)
+        result = places365_classifier.classify_scene(sample_image_path)
+
+    print(f"\n  Low-confidence result: {result}")
+
+    assert result["scene_type"] == "unknown"
+    assert 0 <= result["scene_confidence"] <= 1
+    assert len(result["scene_raw_top3"]) == 3
+
+
+def test_classify_scene_unmapped_label_returns_unknown(sample_image_path):
+    """
+    Test that classify_scene returns 'unknown' when the top prediction
+    is a Places365 label that is not in the DREAMS category mapping,
+    even if confidence is high.
+    """
+    # Use a labels list where ALL labels are unmapped
+    unmapped_labels = [f"unlabeled_scene_{i}" for i in range(365)]
+
+    mock_model = MagicMock()
+    mock_output = _make_mock_output(100, 0.9, unmapped_labels)
+    mock_model.return_value = mock_output
+
+    with patch.object(places365_classifier, "_load_model") as mock_load:
+        mock_load.return_value = (mock_model, unmapped_labels)
+        result = places365_classifier.classify_scene(sample_image_path)
+
+    print(f"\n  Unmapped-label result: {result}")
+
+    # scene_type should be "unknown" since none of top3 map to DREAMS categories
+    assert result["scene_type"] == "unknown"
+    assert 0 <= result["scene_confidence"] <= 1
+    assert len(result["scene_raw_top3"]) == 3
+
+
+def test_classify_scene_result_structure(sample_image_path):
+    """
+    Test that the returned dictionary always has the expected keys
+    and value types regardless of classification outcome.
+    """
+    mock_model = MagicMock()
+    mock_output = _make_mock_output(2, 0.8, MOCK_LABELS)  # park
+    mock_model.return_value = mock_output
+
+    with patch.object(places365_classifier, "_load_model") as mock_load:
+        mock_load.return_value = (mock_model, MOCK_LABELS)
+        result = places365_classifier.classify_scene(sample_image_path)
+
+    print(f"\n  Structure check result: {result}")
+
+    # Check keys exist
+    assert "scene_type" in result
+    assert "scene_confidence" in result
+    assert "scene_raw_top3" in result
+
+    # Check types
+    assert isinstance(result["scene_type"], str)
+    assert isinstance(result["scene_confidence"], float)
+    assert isinstance(result["scene_raw_top3"], list)
+
+    # Check scene_type validity
+    assert result["scene_type"] in (places365_classifier.VALID_SCENE_TYPES | {"unknown"})
+
+    # Check scene_raw_top3 entries
+    for entry in result["scene_raw_top3"]:
+        assert "label" in entry
+        assert "confidence" in entry
+        assert isinstance(entry["label"], str)
+        assert isinstance(entry["confidence"], float)
+        assert 0 <= entry["confidence"] <= 1


### PR DESCRIPTION
Adds a basic Places365 scene classification module to the DREAMS photo ingestion pipeline. Each uploaded photo now gets a scene_type field stored in MongoDB alongside existing BLIP captions, CLIP embeddings, and emotion scores.

### What This PR Adds

places365_classifier.py:  standalone scene classification using Places365 ResNet50
Pipeline integration : classify_scene runs after BLIP and CLIP on every photo upload
Three new MongoDB fields per memory: scene_type, scene_confidence, scene_raw_top3
MongoDB index on scene_type for future filtering
Full test suite with mocked model outputs

### Six DREAMS Scene Categories
clinical_or_institutional
 · faith_community
 · recovery_support
 · residential_or_transitional
 · shelter_or_dropin
 · outdoor_or_wilderness

### **BEFORE**
{
  caption: "feeling low today",
  emotion: "sadness 0.82",
  image_embedding: [0.12, -0.05, ...]
}

### **AFTER**
{
  caption: "feeling low today",
  emotion: "sadness 0.82",
  image_embedding: [0.12, -0.05, ...],
  scene_type: "outdoor_or_wilderness",
  scene_confidence: 0.76,
  scene_raw_top3: ["park", "forest_path", "trail"]
}

### Testing

**python -m pytest tests/test_places365_classifier.py -v -s**

<img width="1114" height="203" alt="Screenshot 2026-03-20 at 11 13 05 PM" src="https://github.com/user-attachments/assets/cc782db0-533b-470e-aadd-3f132cb989a7" />
