### PR TITLE
Add Dependency Validation Check to Data Integrity Layer

### DIFF
--- a/data_integrity/validator.py
+++ b/data_integrity/validator.py
@@ -40,7 +40,7 @@ def validate_dependencies() -> dict:
     requirements_path = Path(__file__).resolve().parent.parent / "requirements.txt"
     if not requirements_path.exists():
         logger.warning(
-            "WARNING: requirements.txt not found at %s. Skipping dependency validation.",
+            "requirements.txt not found at %s. Skipping dependency validation.",
             requirements_path,
         )
         return {"valid": True, "missing": []}

--- a/data_integrity/validator.py
+++ b/data_integrity/validator.py
@@ -13,13 +13,77 @@ Example:
 
 import argparse
 import json
+import logging
 import sys
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
 from .reporter import ValidationReport, Severity
 from .schema_validator import validate_schema
 from .path_validator import validate_paths
 from .temporal_validator import validate_temporal
+
+
+logger = logging.getLogger(__name__)
+
+
+# Dependency validation — extends Data Integrity Layer from PR #38
+def validate_dependencies() -> dict:
+    """Check required distributions from requirements.txt and report missing ones.
+
+    This function reads requirements from the project root, extracts package
+    names while ignoring version specifiers/comments, and verifies installation
+    using importlib.metadata.version(). It never raises for missing packages;
+    instead it logs warnings and returns a status dictionary.
+    """
+   
+    requirements_path = Path(__file__).resolve().parent.parent / "requirements.txt"
+    if not requirements_path.exists():
+        logger.warning(
+            "WARNING: requirements.txt not found at %s. Skipping dependency validation.",
+            requirements_path,
+        )
+        return {"valid": True, "missing": []}
+
+    missing_packages = []
+
+    with requirements_path.open("r", encoding="utf-8") as requirements_file:
+        for raw_line in requirements_file:
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+
+            # Remove inline comments and environment markers.
+            line = line.split("#", 1)[0].strip()
+            line = line.split(";", 1)[0].strip()
+            if not line:
+                continue
+
+            # Ignore pip options and nested requirements directives.
+            if line.startswith("-"):
+                continue
+
+            package_name = line
+            for separator in ("==", ">=", "<=", "~=", "!=", ">", "<"):
+                if separator in package_name:
+                    package_name = package_name.split(separator, 1)[0].strip()
+                    break
+
+            # Ignore extras in requirement specifiers (e.g., package[extra]).
+            package_name = package_name.split("[", 1)[0].strip()
+            if not package_name:
+                continue
+
+            try:
+                version(package_name)
+            except PackageNotFoundError:
+                missing_packages.append(package_name)
+                logger.warning(
+                    "WARNING: Required package %s is not installed. Run pip install -r requirements.txt",
+                    package_name,
+                )
+
+    return {"valid": len(missing_packages) == 0, "missing": missing_packages}
 
 
 def main():

--- a/data_integrity/validator.py
+++ b/data_integrity/validator.py
@@ -64,7 +64,7 @@ def validate_dependencies() -> dict:
                 continue
 
             package_name = line
-            for separator in ("==", ">=", "<=", "~=", "!=", ">", "<"):
+            for separator in ("@", "==", ">=", "<=", "~=", "!=", ">", "<"):
                 if separator in package_name:
                     package_name = package_name.split(separator, 1)[0].strip()
                     break

--- a/dreamsApp/app/__init__.py
+++ b/dreamsApp/app/__init__.py
@@ -4,9 +4,19 @@ import os
 from flask_login import LoginManager
 from .models import User  
 from bson.objectid import ObjectId 
+from data_integrity.validator import validate_dependencies
 
 def create_app(test_config=None):
     app = Flask(__name__, instance_relative_config=True)
+
+    dependency_validation = validate_dependencies()
+    if dependency_validation["valid"]:
+        app.logger.info("Dependency validation passed: all required packages are installed.")
+    else:
+        app.logger.warning(
+            "Dependency validation found missing packages: %s",
+            ", ".join(dependency_validation["missing"]),
+        )
 
     # Default config
     app.config.from_mapping(


### PR DESCRIPTION
This PR extends the existing Data Integrity Layer (introduced in PR #38 ) by adding a lightweight dependency validation check during application startup.

Introduces validate_dependencies() to verify all required packages from requirements.txt are installed

Uses importlib.metadata (no new dependencies added)

Logs warnings for any missing packages without breaking the application

Integrates the check into the existing data integrity workflow at startup

This ensures better environment consistency and helps catch missing dependencies early without affecting runtime stability.