### PR TITLE
Safe model initialization and memory cleanup

### DIFF
--- a/analysis_pipeline/steps/caption_embeddings.py
+++ b/analysis_pipeline/steps/caption_embeddings.py
@@ -22,21 +22,21 @@ def run(log: logging.Logger | None = None) -> int:
     """Encode captions with MiniLM and upsert into ChromaDB."""
     _log = log or logger
 
-    from sentence_transformers import SentenceTransformer
-
-    _log.info("Loading sentence model: %s", SENTENCE_MODEL_NAME)
-    model = SentenceTransformer(SENTENCE_MODEL_NAME)
-    _log.info("Sentence model loaded.")
-
-    collection = get_collection("caption_embeddings")
     pending = get_pending_ids("caption_embeddings")
-
     if not pending:
         _log.info("All captions already have embeddings.")
         return 0
 
+    from sentence_transformers import SentenceTransformer
+
+    _log.info("Loading sentence model: %s", SENTENCE_MODEL_NAME)
+    model = None
     conn = get_db()
     try:
+        model = SentenceTransformer(SENTENCE_MODEL_NAME)
+        _log.info("Sentence model loaded.")
+
+        collection = get_collection("caption_embeddings")
         placeholders = ",".join("?" for _ in pending)
         rows = conn.execute(
             f"""SELECT memory_id, caption, generated_caption, user_id
@@ -101,6 +101,13 @@ def run(log: logging.Logger | None = None) -> int:
     finally:
         conn.close()
         # Free MiniLM from RAM
-        del model
+        if model is not None:
+            del model
         gc.collect()
-        _log.info("Sentence model unloaded.")
+        try:
+            import torch
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+        except Exception:
+            pass
+        _log.info("Sentence model unloaded or skipped.")

--- a/analysis_pipeline/steps/caption_embeddings.py
+++ b/analysis_pipeline/steps/caption_embeddings.py
@@ -31,8 +31,9 @@ def run(log: logging.Logger | None = None) -> int:
 
     _log.info("Loading sentence model: %s", SENTENCE_MODEL_NAME)
     model = None
-    conn = get_db()
+    conn = None
     try:
+        conn = get_db()
         model = SentenceTransformer(SENTENCE_MODEL_NAME)
         _log.info("Sentence model loaded.")
 

--- a/analysis_pipeline/steps/caption_embeddings.py
+++ b/analysis_pipeline/steps/caption_embeddings.py
@@ -109,6 +109,6 @@ def run(log: logging.Logger | None = None) -> int:
             import torch
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
-        except Exception:
-            pass
+        except Exception as e:
+            _log.warning("Failed to empty CUDA cache: %s", e)
         _log.info("Sentence model unloaded or skipped.")

--- a/analysis_pipeline/steps/image_embeddings.py
+++ b/analysis_pipeline/steps/image_embeddings.py
@@ -34,6 +34,11 @@ def run(log: logging.Logger | None = None) -> int:
     """Encode images with CLIP and upsert into ChromaDB."""
     _log = log or logger
 
+    pending = get_pending_ids("image_embeddings")
+    if not pending:
+        _log.info("All images already have embeddings.")
+        return 0
+
     # lazy-load heavy dependencies
     import torch
     from PIL import Image
@@ -41,20 +46,17 @@ def run(log: logging.Logger | None = None) -> int:
 
     device = "cuda" if torch.cuda.is_available() else "cpu"
     _log.info("Loading CLIP model '%s' on %s", _HF_CLIP_MODEL, device)
-    model = CLIPModel.from_pretrained(_HF_CLIP_MODEL).to(device)
-    processor = CLIPProcessor.from_pretrained(_HF_CLIP_MODEL)
-    model.eval()
-    _log.info("CLIP loaded.")
 
-    collection = get_collection("image_embeddings")
-    pending = get_pending_ids("image_embeddings")
-
-    if not pending:
-        _log.info("All images already have embeddings.")
-        return 0
-
+    model = None
+    processor = None
     conn = get_db()
     try:
+        model = CLIPModel.from_pretrained(_HF_CLIP_MODEL).to(device)
+        processor = CLIPProcessor.from_pretrained(_HF_CLIP_MODEL)
+        model.eval()
+        _log.info("CLIP loaded.")
+
+        collection = get_collection("image_embeddings")
         # fetch image paths for pending records
         placeholders = ",".join("?" for _ in pending)
         rows = conn.execute(
@@ -135,10 +137,15 @@ def run(log: logging.Logger | None = None) -> int:
     finally:
         conn.close()
         # Free CLIP from RAM
-        del model, processor
+        if model is not None:
+            del model
+        if processor is not None:
+            del processor
         gc.collect()
         try:
-            torch.cuda.empty_cache()
+            import torch
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
         except Exception:
             pass
-        _log.info("CLIP model unloaded.")
+        _log.info("CLIP model unloaded or skipped.")

--- a/analysis_pipeline/steps/image_embeddings.py
+++ b/analysis_pipeline/steps/image_embeddings.py
@@ -49,8 +49,9 @@ def run(log: logging.Logger | None = None) -> int:
 
     model = None
     processor = None
-    conn = get_db()
+    conn = None
     try:
+        conn = get_db()
         model = CLIPModel.from_pretrained(_HF_CLIP_MODEL).to(device)
         processor = CLIPProcessor.from_pretrained(_HF_CLIP_MODEL)
         model.eval()

--- a/analysis_pipeline/steps/image_embeddings.py
+++ b/analysis_pipeline/steps/image_embeddings.py
@@ -147,6 +147,6 @@ def run(log: logging.Logger | None = None) -> int:
             import torch
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
-        except Exception:
+        except Exception as e:
             _log.warning("Failed to empty CUDA cache: %s", e)
         _log.info("CLIP model unloaded or skipped.")

--- a/analysis_pipeline/steps/image_embeddings.py
+++ b/analysis_pipeline/steps/image_embeddings.py
@@ -148,5 +148,5 @@ def run(log: logging.Logger | None = None) -> int:
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
         except Exception:
-            pass
+            _log.warning("Failed to empty CUDA cache: %s", e)
         _log.info("CLIP model unloaded or skipped.")


### PR DESCRIPTION
### Summary
 Used a `model = None` initialization for the image and caption/text embedding models, inside a `try...finally` block to prevent a double crash if the model fails to load. Also, added a command to empty the GPU cache after each step so the memory usage remains efficient.