### PR TITLE
Add embedding L2 normalization utility and tests

### DIFF
--- a/dreamsApp/app/utils/embeddings.py
+++ b/dreamsApp/app/utils/embeddings.py
@@ -1,0 +1,8 @@
+import numpy as np
+
+
+def l2_normalize(vec: np.ndarray) -> np.ndarray:
+    norm = np.linalg.norm(vec)
+    if norm == 0:
+        return vec.copy()
+    return vec / norm

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,0 +1,21 @@
+from importlib.util import module_from_spec, spec_from_file_location
+
+import numpy as np
+
+
+spec = spec_from_file_location("embeddings", "dreamsApp/app/utils/embeddings.py")
+embeddings = module_from_spec(spec)
+spec.loader.exec_module(embeddings)
+l2_normalize = embeddings.l2_normalize
+
+
+def test_l2_normalize_normal_vector():
+    vec = np.array([3.0, 4.0])
+    normalized = l2_normalize(vec)
+    assert np.allclose(normalized, np.array([0.6, 0.8]))
+
+
+def test_l2_normalize_zero_vector():
+    vec = np.zeros(3)
+    normalized = l2_normalize(vec)
+    assert np.array_equal(normalized, vec)


### PR DESCRIPTION
## Summary

Adds a minimal utility function for L2 normalization of embedding vectors.

## Details

* Introduces `l2_normalize` helper in `utils/embeddings.py`
* Handles zero vectors safely
* Includes a small unit test

## Motivation

Provides a consistent normalization step for embedding-based workflows, which can be reused in clustering and multimodal fusion logic.

## Notes

This change is intentionally minimal and does not integrate with existing modules yet.
