### PR TITLE
feat: CHIME-based place emotion signatures and recovery anchor detection

### DIFF
--- a/dreamsApp/core/extra/place_emotion_signature.py
+++ b/dreamsApp/core/extra/place_emotion_signature.py
@@ -1,0 +1,129 @@
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+import math
+
+
+CHIME_DIMENSIONS = ['Connectedness', 'Hope', 'Identity', 'Meaning', 'Empowerment']
+
+
+@dataclass
+class PlaceEmotionSignature:
+    """
+    Mean CHIME profile for a location type across all visits.
+
+    place_type  : category label, e.g. 'church', 'park'
+    chime_vector: mean score per CHIME dimension
+    visit_count : number of visits used to build the profile
+    volatility  : RMS std-dev across dimensions (low = emotionally stable place)
+    """
+    place_type: str
+    chime_vector: Dict[str, float]
+    visit_count: int = 0
+    volatility: float = 0.0
+
+
+def build_place_signature(
+    place_type: str,
+    chime_results: List[Dict[str, float]]
+) -> PlaceEmotionSignature:
+    """
+    Aggregate per-visit CHIME dicts into a single PlaceEmotionSignature.
+
+    Missing dimensions in any visit default to 0.0.
+    Volatility is the RMS of per-dimension population std-devs.
+    """
+    if not chime_results:
+        return PlaceEmotionSignature(
+            place_type=place_type,
+            chime_vector={dim: 0.0 for dim in CHIME_DIMENSIONS},
+            visit_count=0,
+            volatility=0.0
+        )
+
+    n = len(chime_results)
+
+    mean_vector = {
+        dim: sum(r.get(dim, 0.0) for r in chime_results) / n
+        for dim in CHIME_DIMENSIONS
+    }
+
+    total_variance = sum(
+        sum((r.get(dim, 0.0) - mean_vector[dim]) ** 2 for r in chime_results) / n
+        for dim in CHIME_DIMENSIONS
+    )
+    volatility = math.sqrt(total_variance / len(CHIME_DIMENSIONS))
+
+    return PlaceEmotionSignature(
+        place_type=place_type,
+        chime_vector=mean_vector,
+        visit_count=n,
+        volatility=volatility
+    )
+
+
+def chime_proximity(
+    sig_a: PlaceEmotionSignature,
+    sig_b: PlaceEmotionSignature,
+    min_visits: int = 1
+) -> float:
+    """
+    Cosine similarity between two place-type CHIME vectors.
+
+    Returns 0.5 when either signature has fewer than min_visits
+    (not enough data to be confident either way).
+    """
+    if sig_a.visit_count < min_visits or sig_b.visit_count < min_visits:
+        return 0.5
+
+    vec_a = [sig_a.chime_vector.get(d, 0.0) for d in CHIME_DIMENSIONS]
+    vec_b = [sig_b.chime_vector.get(d, 0.0) for d in CHIME_DIMENSIONS]
+
+    dot = sum(a * b for a, b in zip(vec_a, vec_b))
+    mag_a = math.sqrt(sum(a ** 2 for a in vec_a))
+    mag_b = math.sqrt(sum(b ** 2 for b in vec_b))
+
+    if mag_a == 0 or mag_b == 0:
+        return 0.0
+
+    return dot / (mag_a * mag_b)
+
+
+def detect_recovery_anchors(
+    signatures: Dict[str, PlaceEmotionSignature],
+    anchor_dimensions: List[str] = None,
+    threshold: float = 0.6,
+    min_visits: int = 2
+) -> List[Tuple[str, float, str]]:
+    """
+    Return place types that consistently trigger recovery-relevant CHIME dimensions.
+
+    anchor_score = best_dimension_score * (1 - volatility)
+    High score + low volatility = stable recovery anchor.
+
+    Returns list of (place_type, anchor_score, dominant_dimension)
+    sorted by anchor_score descending.
+    """
+    if anchor_dimensions is None:
+        anchor_dimensions = ['Hope', 'Connectedness']
+
+    anchors = []
+    for place_type, sig in signatures.items():
+        if sig.visit_count < min_visits:
+            continue
+
+        best_dim = max(anchor_dimensions, key=lambda d: sig.chime_vector.get(d, 0.0))
+        best_score = sig.chime_vector.get(best_dim, 0.0)
+        anchor_score = best_score * max(0.0, 1.0 - sig.volatility)
+
+        if anchor_score >= threshold:
+            anchors.append((place_type, anchor_score, best_dim))
+
+    return sorted(anchors, key=lambda x: x[1], reverse=True)
+
+
+def get_dominant_chime_dimension(sig: PlaceEmotionSignature) -> Tuple[str, float]:
+    """Return (dimension_name, score) for the highest-scoring CHIME dimension."""
+    if not sig.chime_vector:
+        return ('None', 0.0)
+    best_dim = max(sig.chime_vector, key=sig.chime_vector.get)
+    return (best_dim, sig.chime_vector[best_dim])

--- a/dreamsApp/core/extra/place_emotion_signature.py
+++ b/dreamsApp/core/extra/place_emotion_signature.py
@@ -79,8 +79,8 @@ def chime_proximity(
     vec_b = [sig_b.chime_vector.get(d, 0.0) for d in CHIME_DIMENSIONS]
 
     dot = sum(a * b for a, b in zip(vec_a, vec_b))
-    mag_a = math.sqrt(sum(a ** 2 for a in vec_a))
-    mag_b = math.sqrt(sum(b ** 2 for b in vec_b))
+    mag_a = math.hypot(*vec_a)
+    mag_b = math.hypot(*vec_b)
 
     if mag_a == 0 or mag_b == 0:
         return 0.0

--- a/dreamsApp/core/graph/place_narrative_bridge.py
+++ b/dreamsApp/core/graph/place_narrative_bridge.py
@@ -1,0 +1,106 @@
+from typing import Dict, List, Tuple
+
+from dreamsApp.core.extra.place_emotion_signature import (
+    PlaceEmotionSignature,
+    chime_proximity,
+)
+from dreamsApp.core.graph.temporal_narrative_graph import (
+    NarrativeEdge,
+    TemporalNarrativeGraph,
+)
+
+
+def enrich_narrative_edges_with_place_proximity(
+    graph: TemporalNarrativeGraph,
+    episode_place_signatures: Dict[int, PlaceEmotionSignature],
+    place_weight: float = 0.3
+) -> TemporalNarrativeGraph:
+    """
+    Blend temporal edge weights with CHIME-based place proximity.
+
+    For each edge where both episodes have a place signature, the new
+    weight is:
+        (1 - place_weight) * temporal_weight + place_weight * chime_proximity
+
+    Episodes with no signature keep their original weight unchanged.
+
+    place_weight=0.0 → pure temporal (no change)
+    place_weight=1.0 → pure place proximity
+
+    Raises ValueError if place_weight is outside [0.0, 1.0].
+    """
+    if not (0.0 <= place_weight <= 1.0):
+        raise ValueError(f"place_weight must be in [0.0, 1.0], got {place_weight}")
+
+    enriched_edges = []
+    for edge in graph.edges:
+        sig_a = episode_place_signatures.get(edge.source_index)
+        sig_b = episode_place_signatures.get(edge.target_index)
+
+        if sig_a is not None and sig_b is not None:
+            place_prox = chime_proximity(sig_a, sig_b)
+            new_weight = (1.0 - place_weight) * edge.weight + place_weight * place_prox
+            new_weight = max(0.0, min(1.0, new_weight))
+        else:
+            new_weight = edge.weight
+
+        enriched_edges.append(NarrativeEdge(
+            source_index=edge.source_index,
+            target_index=edge.target_index,
+            relation=edge.relation,
+            weight=new_weight
+        ))
+
+    return TemporalNarrativeGraph(
+        nodes=graph.nodes,
+        edges=tuple(enriched_edges),
+        adjacency_threshold=graph.adjacency_threshold
+    )
+
+
+def compute_place_proximity_matrix(
+    signatures: Dict[str, PlaceEmotionSignature]
+) -> Dict[str, Dict[str, float]]:
+    """
+    Pairwise CHIME proximity between all place types.
+
+    Returns a symmetric nested dict where matrix[a][b] == matrix[b][a]
+    and matrix[a][a] == 1.0.
+    """
+    place_types = list(signatures.keys())
+    matrix: Dict[str, Dict[str, float]] = {}
+
+    for pt_a in place_types:
+        matrix[pt_a] = {}
+        for pt_b in place_types:
+            if pt_a == pt_b:
+                matrix[pt_a][pt_b] = 1.0
+            else:
+                matrix[pt_a][pt_b] = chime_proximity(signatures[pt_a], signatures[pt_b])
+
+    return matrix
+
+
+def find_emotionally_proximate_pairs(
+    signatures: Dict[str, PlaceEmotionSignature],
+    threshold: float = 0.7
+) -> List[Tuple[str, str, float]]:
+    """
+    Place-type pairs whose CHIME proximity is at or above threshold.
+
+    Useful for surfacing unexpected connections - places that are
+    categorically different but emotionally similar for this person.
+
+    Returns list of (place_type_a, place_type_b, score) sorted descending.
+    No self-pairs, no duplicates.
+    """
+    place_types = list(signatures.keys())
+    pairs = []
+
+    for i, pt_a in enumerate(place_types):
+        for pt_b in place_types[i + 1:]:
+            score = chime_proximity(signatures[pt_a], signatures[pt_b])
+            if score >= threshold:
+                pairs.append((pt_a, pt_b, score))
+
+    return sorted(pairs, key=lambda x: x[2], reverse=True)

--- a/tests/test_place_emotion_signature.py
+++ b/tests/test_place_emotion_signature.py
@@ -1,0 +1,239 @@
+import math
+import pytest
+from dreamsApp.core.extra.place_emotion_signature import (
+    CHIME_DIMENSIONS,
+    PlaceEmotionSignature,
+    build_place_signature,
+    chime_proximity,
+    detect_recovery_anchors,
+    get_dominant_chime_dimension,
+)
+
+
+@pytest.fixture
+def church_visits():
+    return [
+        {'Connectedness': 0.7, 'Hope': 0.9, 'Identity': 0.3, 'Meaning': 0.6, 'Empowerment': 0.4},
+        {'Connectedness': 0.75, 'Hope': 0.85, 'Identity': 0.35, 'Meaning': 0.65, 'Empowerment': 0.45},
+        {'Connectedness': 0.72, 'Hope': 0.88, 'Identity': 0.32, 'Meaning': 0.62, 'Empowerment': 0.42},
+    ]
+
+
+@pytest.fixture
+def community_center_visits():
+    return [
+        {'Connectedness': 0.82, 'Hope': 0.79, 'Identity': 0.4, 'Meaning': 0.55, 'Empowerment': 0.5},
+        {'Connectedness': 0.85, 'Hope': 0.81, 'Identity': 0.38, 'Meaning': 0.58, 'Empowerment': 0.52},
+    ]
+
+
+@pytest.fixture
+def hospital_visits():
+    return [
+        {'Connectedness': 0.2, 'Hope': 0.3, 'Identity': 0.6, 'Meaning': 0.4, 'Empowerment': 0.25},
+        {'Connectedness': 0.25, 'Hope': 0.28, 'Identity': 0.55, 'Meaning': 0.45, 'Empowerment': 0.3},
+    ]
+
+
+@pytest.fixture
+def church_sig(church_visits):
+    return build_place_signature('church', church_visits)
+
+
+@pytest.fixture
+def community_sig(community_center_visits):
+    return build_place_signature('community_center', community_center_visits)
+
+
+@pytest.fixture
+def hospital_sig(hospital_visits):
+    return build_place_signature('hospital', hospital_visits)
+
+
+class TestBuildPlaceSignature:
+
+    def test_returns_place_emotion_signature(self, church_visits):
+        sig = build_place_signature('church', church_visits)
+        assert isinstance(sig, PlaceEmotionSignature)
+
+    def test_place_type_stored(self, church_visits):
+        sig = build_place_signature('church', church_visits)
+        assert sig.place_type == 'church'
+
+    def test_visit_count(self, church_visits):
+        sig = build_place_signature('church', church_visits)
+        assert sig.visit_count == 3
+
+    def test_mean_vector_computed(self, church_visits):
+        sig = build_place_signature('church', church_visits)
+        expected_hope = (0.9 + 0.85 + 0.88) / 3
+        assert abs(sig.chime_vector['Hope'] - expected_hope) < 1e-9
+
+    def test_all_chime_dimensions_present(self, church_visits):
+        sig = build_place_signature('church', church_visits)
+        for dim in CHIME_DIMENSIONS:
+            assert dim in sig.chime_vector
+
+    def test_volatility_is_non_negative(self, church_visits):
+        sig = build_place_signature('church', church_visits)
+        assert sig.volatility >= 0.0
+
+    def test_low_volatility_for_consistent_visits(self):
+        visits = [
+            {'Connectedness': 0.7, 'Hope': 0.9, 'Identity': 0.3, 'Meaning': 0.6, 'Empowerment': 0.4}
+        ] * 5
+        sig = build_place_signature('church', visits)
+        assert sig.volatility == 0.0
+
+    def test_high_volatility_for_inconsistent_visits(self):
+        visits = [
+            {'Connectedness': 0.1, 'Hope': 0.1, 'Identity': 0.1, 'Meaning': 0.1, 'Empowerment': 0.1},
+            {'Connectedness': 0.9, 'Hope': 0.9, 'Identity': 0.9, 'Meaning': 0.9, 'Empowerment': 0.9},
+        ]
+        sig = build_place_signature('volatile_place', visits)
+        assert sig.volatility > 0.3
+
+    def test_empty_visits_returns_zero_vector(self):
+        sig = build_place_signature('unknown', [])
+        assert sig.visit_count == 0
+        for dim in CHIME_DIMENSIONS:
+            assert sig.chime_vector[dim] == 0.0
+
+    def test_empty_visits_zero_volatility(self):
+        sig = build_place_signature('unknown', [])
+        assert sig.volatility == 0.0
+
+    def test_single_visit(self):
+        visits = [{'Connectedness': 0.8, 'Hope': 0.7, 'Identity': 0.5, 'Meaning': 0.6, 'Empowerment': 0.4}]
+        sig = build_place_signature('park', visits)
+        assert sig.visit_count == 1
+        assert sig.chime_vector['Hope'] == 0.7
+        assert sig.volatility == 0.0
+
+    def test_missing_dimension_defaults_to_zero(self):
+        visits = [{'Hope': 0.8}]
+        sig = build_place_signature('partial', visits)
+        assert sig.chime_vector['Hope'] == 0.8
+        assert sig.chime_vector['Connectedness'] == 0.0
+
+
+class TestChimeProximity:
+
+    def test_identical_signatures_return_one(self, church_visits):
+        sig = build_place_signature('church', church_visits)
+        assert abs(chime_proximity(sig, sig) - 1.0) < 1e-9
+
+    def test_similar_signatures_high_proximity(self, church_sig, community_sig):
+        score = chime_proximity(church_sig, community_sig)
+        assert score > 0.8
+
+    def test_dissimilar_signatures_lower_proximity(self, church_sig, community_sig, hospital_sig):
+        assert chime_proximity(church_sig, hospital_sig) < chime_proximity(church_sig, community_sig)
+
+    def test_proximity_range(self, church_sig, hospital_sig):
+        score = chime_proximity(church_sig, hospital_sig)
+        assert 0.0 <= score <= 1.0
+
+    def test_symmetry(self, church_sig, hospital_sig):
+        assert abs(
+            chime_proximity(church_sig, hospital_sig) -
+            chime_proximity(hospital_sig, church_sig)
+        ) < 1e-9
+
+    def test_zero_vector_returns_zero(self):
+        zero_sig = PlaceEmotionSignature('empty', {d: 0.0 for d in CHIME_DIMENSIONS}, visit_count=1)
+        other_sig = PlaceEmotionSignature('other', {'Hope': 0.9, 'Connectedness': 0.8, 'Identity': 0.3, 'Meaning': 0.5, 'Empowerment': 0.4}, visit_count=1)
+        assert chime_proximity(zero_sig, other_sig) == 0.0
+
+    def test_insufficient_visits_returns_neutral(self):
+        sig_a = PlaceEmotionSignature('a', {'Hope': 0.9, 'Connectedness': 0.8, 'Identity': 0.3, 'Meaning': 0.5, 'Empowerment': 0.4}, visit_count=0)
+        sig_b = PlaceEmotionSignature('b', {'Hope': 0.1, 'Connectedness': 0.2, 'Identity': 0.8, 'Meaning': 0.3, 'Empowerment': 0.2}, visit_count=3)
+        assert chime_proximity(sig_a, sig_b, min_visits=1) == 0.5
+
+    def test_min_visits_threshold(self, church_sig):
+        low_visit_sig = PlaceEmotionSignature('rare', {'Hope': 0.9, 'Connectedness': 0.8, 'Identity': 0.3, 'Meaning': 0.5, 'Empowerment': 0.4}, visit_count=1)
+        assert chime_proximity(church_sig, low_visit_sig, min_visits=2) == 0.5
+        assert chime_proximity(church_sig, low_visit_sig, min_visits=1) != 0.5
+
+
+class TestDetectRecoveryAnchors:
+
+    @pytest.fixture
+    def signatures(self, church_sig, community_sig, hospital_sig):
+        return {'church': church_sig, 'community_center': community_sig, 'hospital': hospital_sig}
+
+    def test_returns_list(self, signatures):
+        assert isinstance(detect_recovery_anchors(signatures), list)
+
+    def test_anchor_tuple_structure(self, signatures):
+        for item in detect_recovery_anchors(signatures, threshold=0.0):
+            place_type, score, dimension = item
+            assert isinstance(place_type, str)
+            assert isinstance(score, float)
+            assert isinstance(dimension, str)
+
+    def test_sorted_by_score_descending(self, signatures):
+        result = detect_recovery_anchors(signatures, threshold=0.0)
+        scores = [r[1] for r in result]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_church_is_top_anchor(self, signatures):
+        result = detect_recovery_anchors(signatures, threshold=0.0)
+        if result:
+            assert result[0][0] in ('church', 'community_center')
+
+    def test_hospital_not_anchor_with_high_threshold(self, signatures):
+        result = detect_recovery_anchors(signatures, threshold=0.7)
+        assert 'hospital' not in [r[0] for r in result]
+
+    def test_threshold_filters_correctly(self, signatures):
+        all_results = detect_recovery_anchors(signatures, threshold=0.0)
+        filtered = detect_recovery_anchors(signatures, threshold=0.9)
+        assert len(filtered) <= len(all_results)
+
+    def test_min_visits_filters_single_visit(self):
+        sigs = {
+            'church': PlaceEmotionSignature('church', {'Hope': 0.9, 'Connectedness': 0.8, 'Identity': 0.3, 'Meaning': 0.5, 'Empowerment': 0.4}, visit_count=1),
+            'park': PlaceEmotionSignature('park', {'Hope': 0.85, 'Connectedness': 0.75, 'Identity': 0.35, 'Meaning': 0.55, 'Empowerment': 0.45}, visit_count=3),
+        }
+        result = detect_recovery_anchors(sigs, threshold=0.0, min_visits=2)
+        assert 'church' not in [r[0] for r in result]
+        assert 'park' in [r[0] for r in result]
+
+    def test_empty_signatures_returns_empty(self):
+        assert detect_recovery_anchors({}) == []
+
+    def test_custom_anchor_dimensions(self, signatures):
+        result = detect_recovery_anchors(signatures, anchor_dimensions=['Meaning', 'Identity'], threshold=0.0)
+        for _, _, dim in result:
+            assert dim in ['Meaning', 'Identity']
+
+    def test_volatility_penalizes_anchor_score(self):
+        stable = PlaceEmotionSignature('stable', {'Hope': 0.9, 'Connectedness': 0.8, 'Identity': 0.3, 'Meaning': 0.5, 'Empowerment': 0.4}, visit_count=3, volatility=0.0)
+        volatile = PlaceEmotionSignature('volatile', {'Hope': 0.9, 'Connectedness': 0.8, 'Identity': 0.3, 'Meaning': 0.5, 'Empowerment': 0.4}, visit_count=3, volatility=0.8)
+        result = detect_recovery_anchors({'stable': stable, 'volatile': volatile}, threshold=0.0)
+        scores = {r[0]: r[1] for r in result}
+        assert scores.get('stable', 0) > scores.get('volatile', 0)
+
+
+class TestGetDominantChimeDimension:
+
+    def test_returns_tuple(self, church_sig):
+        assert isinstance(get_dominant_chime_dimension(church_sig), tuple)
+
+    def test_returns_highest_dimension(self):
+        sig = PlaceEmotionSignature('test', {'Connectedness': 0.3, 'Hope': 0.9, 'Identity': 0.2, 'Meaning': 0.5, 'Empowerment': 0.4}, visit_count=2)
+        dim, score = get_dominant_chime_dimension(sig)
+        assert dim == 'Hope'
+        assert score == 0.9
+
+    def test_empty_vector_returns_none(self):
+        sig = PlaceEmotionSignature('empty', {}, visit_count=0)
+        dim, score = get_dominant_chime_dimension(sig)
+        assert dim == 'None'
+        assert score == 0.0
+
+    def test_church_dominant_is_hope(self, church_sig):
+        dim, score = get_dominant_chime_dimension(church_sig)
+        assert dim == 'Hope'
+        assert score > 0.8

--- a/tests/test_place_narrative_bridge.py
+++ b/tests/test_place_narrative_bridge.py
@@ -1,0 +1,225 @@
+import pytest
+from datetime import datetime, timedelta
+
+from dreamsApp.core.extra.place_emotion_signature import (
+    PlaceEmotionSignature,
+    build_place_signature,
+)
+from dreamsApp.core.graph.place_narrative_bridge import (
+    enrich_narrative_edges_with_place_proximity,
+    compute_place_proximity_matrix,
+    find_emotionally_proximate_pairs,
+)
+from dreamsApp.core.graph.temporal_narrative_graph import (
+    NarrativeEdge,
+    TemporalNarrativeGraph,
+    build_narrative_graph,
+)
+from dreamsApp.core.graph.emotion_episode import Episode
+from dreamsApp.core.graph.emotion_timeline import EmotionEvent
+
+
+def make_episode(start_offset_days: int, duration_days: int = 1) -> Episode:
+    base = datetime(2024, 1, 1)
+    start = base + timedelta(days=start_offset_days)
+    end = start + timedelta(days=duration_days)
+    return Episode(
+        start_time=start,
+        end_time=end,
+        events=(EmotionEvent(timestamp=start, emotion_label='positive', score=0.8),)
+    )
+
+
+def make_simple_graph() -> TemporalNarrativeGraph:
+    return build_narrative_graph(
+        [make_episode(0), make_episode(2), make_episode(5)],
+        adjacency_threshold=timedelta(days=3),
+        include_disjoint_edges=True
+    )
+
+
+def make_sig(place_type: str, hope: float, connectedness: float, visit_count: int = 3) -> PlaceEmotionSignature:
+    return PlaceEmotionSignature(
+        place_type=place_type,
+        chime_vector={'Hope': hope, 'Connectedness': connectedness, 'Identity': 0.3, 'Meaning': 0.5, 'Empowerment': 0.4},
+        visit_count=visit_count,
+        volatility=0.1
+    )
+
+
+class TestEnrichNarrativeEdges:
+
+    def test_returns_temporal_narrative_graph(self):
+        assert isinstance(enrich_narrative_edges_with_place_proximity(make_simple_graph(), {}), TemporalNarrativeGraph)
+
+    def test_same_node_count(self):
+        graph = make_simple_graph()
+        assert enrich_narrative_edges_with_place_proximity(graph, {}).node_count() == graph.node_count()
+
+    def test_same_edge_count(self):
+        graph = make_simple_graph()
+        assert enrich_narrative_edges_with_place_proximity(graph, {}).edge_count() == graph.edge_count()
+
+    def test_no_signatures_preserves_weights(self):
+        graph = make_simple_graph()
+        result = enrich_narrative_edges_with_place_proximity(graph, {})
+        for orig, enriched in zip(graph.edges, result.edges):
+            assert orig.weight == enriched.weight
+
+    def test_similar_place_types_increase_weight(self):
+        graph = make_simple_graph()
+        sigs = {0: make_sig('church', hope=0.9, connectedness=0.8), 1: make_sig('community_center', hope=0.85, connectedness=0.82)}
+        result = enrich_narrative_edges_with_place_proximity(graph, sigs, place_weight=0.3)
+        orig = next(e for e in graph.edges if e.source_index == 0 and e.target_index == 1)
+        new = next(e for e in result.edges if e.source_index == 0 and e.target_index == 1)
+        assert new.weight >= orig.weight * 0.9
+
+    def test_dissimilar_place_types_may_lower_weight(self):
+        graph = make_simple_graph()
+        sigs = {
+            0: make_sig('church', hope=0.9, connectedness=0.8),
+            1: PlaceEmotionSignature('hospital', {'Hope': 0.2, 'Connectedness': 0.2, 'Identity': 0.8, 'Meaning': 0.4, 'Empowerment': 0.3}, visit_count=3, volatility=0.1),
+        }
+        result = enrich_narrative_edges_with_place_proximity(graph, sigs, place_weight=0.5)
+        orig = next(e for e in graph.edges if e.source_index == 0 and e.target_index == 1)
+        new = next(e for e in result.edges if e.source_index == 0 and e.target_index == 1)
+        assert new.weight <= orig.weight + 0.1
+
+    def test_enriched_weights_in_valid_range(self):
+        graph = make_simple_graph()
+        sigs = {0: make_sig('church', 0.9, 0.8), 1: make_sig('park', 0.7, 0.75), 2: make_sig('hospital', 0.2, 0.2)}
+        result = enrich_narrative_edges_with_place_proximity(graph, sigs)
+        for edge in result.edges:
+            assert 0.0 <= edge.weight <= 1.0
+
+    def test_relations_preserved(self):
+        graph = make_simple_graph()
+        result = enrich_narrative_edges_with_place_proximity(graph, {0: make_sig('church', 0.9, 0.8)})
+        for orig, enriched in zip(graph.edges, result.edges):
+            assert orig.relation == enriched.relation
+
+    def test_invalid_place_weight_raises(self):
+        graph = make_simple_graph()
+        with pytest.raises(ValueError):
+            enrich_narrative_edges_with_place_proximity(graph, {}, place_weight=1.5)
+        with pytest.raises(ValueError):
+            enrich_narrative_edges_with_place_proximity(graph, {}, place_weight=-0.1)
+
+    def test_empty_graph_returns_empty(self):
+        empty = TemporalNarrativeGraph(nodes=(), edges=())
+        result = enrich_narrative_edges_with_place_proximity(empty, {})
+        assert result.edge_count() == 0
+
+    def test_place_weight_zero_preserves_all_weights(self):
+        graph = make_simple_graph()
+        sigs = {0: make_sig('church', 0.9, 0.8), 1: make_sig('park', 0.7, 0.75)}
+        result = enrich_narrative_edges_with_place_proximity(graph, sigs, place_weight=0.0)
+        for orig, enriched in zip(graph.edges, result.edges):
+            assert abs(orig.weight - enriched.weight) < 1e-9
+
+    def test_partial_signatures_only_enriches_covered_edges(self):
+        graph = make_simple_graph()
+        sigs = {0: make_sig('church', 0.9, 0.8)}
+        result = enrich_narrative_edges_with_place_proximity(graph, sigs, place_weight=0.5)
+        orig_01 = next(e for e in graph.edges if e.source_index == 0 and e.target_index == 1)
+        new_01 = next(e for e in result.edges if e.source_index == 0 and e.target_index == 1)
+        assert orig_01.weight == new_01.weight
+
+
+class TestComputePlaceProximityMatrix:
+
+    @pytest.fixture
+    def signatures(self):
+        return {
+            'church': make_sig('church', hope=0.9, connectedness=0.8),
+            'community_center': make_sig('community_center', hope=0.85, connectedness=0.82),
+            'hospital': PlaceEmotionSignature('hospital', {'Hope': 0.2, 'Connectedness': 0.2, 'Identity': 0.8, 'Meaning': 0.4, 'Empowerment': 0.3}, visit_count=3, volatility=0.1),
+        }
+
+    def test_returns_dict(self, signatures):
+        assert isinstance(compute_place_proximity_matrix(signatures), dict)
+
+    def test_diagonal_is_one(self, signatures):
+        matrix = compute_place_proximity_matrix(signatures)
+        for pt in signatures:
+            assert abs(matrix[pt][pt] - 1.0) < 1e-9
+
+    def test_symmetric(self, signatures):
+        matrix = compute_place_proximity_matrix(signatures)
+        for pt_a in signatures:
+            for pt_b in signatures:
+                assert abs(matrix[pt_a][pt_b] - matrix[pt_b][pt_a]) < 1e-9
+
+    def test_all_pairs_present(self, signatures):
+        matrix = compute_place_proximity_matrix(signatures)
+        for pt_a in signatures:
+            for pt_b in signatures:
+                assert pt_b in matrix[pt_a]
+
+    def test_church_community_higher_than_church_hospital(self, signatures):
+        matrix = compute_place_proximity_matrix(signatures)
+        assert matrix['church']['community_center'] > matrix['church']['hospital']
+
+    def test_empty_returns_empty(self):
+        assert compute_place_proximity_matrix({}) == {}
+
+    def test_values_in_range(self, signatures):
+        matrix = compute_place_proximity_matrix(signatures)
+        for pt_a in signatures:
+            for pt_b in signatures:
+                assert 0.0 <= matrix[pt_a][pt_b] <= 1.0
+
+
+class TestFindEmotionallyProximatePairs:
+
+    @pytest.fixture
+    def signatures(self):
+        return {
+            'church': make_sig('church', hope=0.9, connectedness=0.8),
+            'community_center': make_sig('community_center', hope=0.85, connectedness=0.82),
+            'hospital': PlaceEmotionSignature('hospital', {'Hope': 0.2, 'Connectedness': 0.2, 'Identity': 0.8, 'Meaning': 0.4, 'Empowerment': 0.3}, visit_count=3, volatility=0.1),
+        }
+
+    def test_returns_list(self, signatures):
+        assert isinstance(find_emotionally_proximate_pairs(signatures), list)
+
+    def test_tuple_structure(self, signatures):
+        for pt_a, pt_b, score in find_emotionally_proximate_pairs(signatures, threshold=0.0):
+            assert isinstance(pt_a, str)
+            assert isinstance(pt_b, str)
+            assert isinstance(score, float)
+
+    def test_no_self_pairs(self, signatures):
+        for pt_a, pt_b, _ in find_emotionally_proximate_pairs(signatures, threshold=0.0):
+            assert pt_a != pt_b
+
+    def test_sorted_descending(self, signatures):
+        result = find_emotionally_proximate_pairs(signatures, threshold=0.0)
+        scores = [r[2] for r in result]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_threshold_filters(self, signatures):
+        all_pairs = find_emotionally_proximate_pairs(signatures, threshold=0.0)
+        filtered = find_emotionally_proximate_pairs(signatures, threshold=0.9)
+        assert len(filtered) <= len(all_pairs)
+        for _, _, score in filtered:
+            assert score >= 0.9
+
+    def test_church_community_is_top_pair(self, signatures):
+        result = find_emotionally_proximate_pairs(signatures, threshold=0.0)
+        if result:
+            assert set([result[0][0], result[0][1]]) == {'church', 'community_center'}
+
+    def test_no_duplicate_pairs(self, signatures):
+        result = find_emotionally_proximate_pairs(signatures, threshold=0.0)
+        seen = set()
+        for pt_a, pt_b, _ in result:
+            pair = frozenset([pt_a, pt_b])
+            assert pair not in seen
+            seen.add(pair)
+
+    def test_empty_returns_empty(self):
+        assert find_emotionally_proximate_pairs({}) == []
+
+    def test_single_signature_returns_empty(self):
+        assert find_emotionally_proximate_pairs({'church': make_sig('church', 0.9, 0.8)}, threshold=0.0) == []


### PR DESCRIPTION
The proximity calculator handles what a place ***is***— category, language, culture. But it says nothing about how a person ***feels*** at a type of place across multiple visits. Two places might score identical on categorical proximity but feel completely different emotionally. That gap is what this PR tries to address.

The idea: aggregate CHIME scores across all visits to places of the same type, and use that as an emotional fingerprint for the place type — not the individual location.

## What's in this PR

**`dreamsApp/core/extra/place_emotion_signature.py`**

- `PlaceEmotionSignature` — dataclass holding mean CHIME vector + volatility (how consistent the emotional response is across visits)
- `build_place_signature(place_type, chime_results)` — aggregates per-visit CHIME dicts into a single profile
- `chime_proximity(sig_a, sig_b)` — cosine similarity between two place-type profiles
- `detect_recovery_anchors(signatures)` — finds place types that consistently score high on Hope/Connectedness with low volatility across visits
- `get_dominant_chime_dimension(sig)` — returns the strongest CHIME dimension for a place type

**`dreamsApp/core/graph/place_narrative_bridge.py`**

- `enrich_narrative_edges_with_place_proximity(graph, episode_place_signatures, place_weight=0.3)` — blends existing temporal edge weights with CHIME proximity. Two episodes at emotionally similar place types get a stronger connection than two at emotionally distant ones, even if temporally close.
- `compute_place_proximity_matrix(signatures)` — pairwise proximity across all place types
- `find_emotionally_proximate_pairs(signatures, threshold)` — surfaces place types that are categorically different but emotionally similar for this person

## Local output (simulated CHIME scores)

The output below uses simulated CHIME scores to simulate what real pipeline output would look like — in production these would come from the CHIME model analyzing the person's photo captions per visit.
<img width="598" height="902" alt="Screenshot 2026-04-23 174901" src="https://github.com/user-attachments/assets/05cb762e-1ab3-45e8-849d-fc08bf1981f5" />



## Tests

62 tests, all passing.

<img width="831" height="912" alt="Screenshot 2026-04-23 172635" src="https://github.com/user-attachments/assets/db3149d9-060c-4385-a1b0-4c56051eab60" />


## Notes

- `place_weight` is configurable (default 0.3), so the balance between temporal and emotional proximity can be tuned
- Builds on `proximity_calculator.py` (PR #176) and the CHIME infrastructure in `advanced_sentiment.py`

@pradeeban - happy to hear if this direction makes sense for the research goals, or if there's a different angle worth exploring.
