### PR TITLE
feat: proximity trajectory analysis for emotional recovery patterns by place type

### DIFF
--- a/dreamsApp/core/extra/proximity_trajectory.py
+++ b/dreamsApp/core/extra/proximity_trajectory.py
@@ -17,6 +17,7 @@ Builds on:
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Dict, List, Optional, Tuple
+import math
 
 
 CHIME_DIMENSIONS = ['Connectedness', 'Hope', 'Identity', 'Meaning', 'Empowerment']

--- a/dreamsApp/core/extra/proximity_trajectory.py
+++ b/dreamsApp/core/extra/proximity_trajectory.py
@@ -72,7 +72,7 @@ def build_place_trajectories(
         n = len(place_visits)
 
         x_mean = (n - 1) / 2.0
-        denominator = sum((i - x_mean) ** 2 for i in range(n))
+        denominator = n * (n**2 - 1) / 12.0
 
         trend: Dict[str, float] = {}
         total_variance = 0.0

--- a/dreamsApp/core/extra/proximity_trajectory.py
+++ b/dreamsApp/core/extra/proximity_trajectory.py
@@ -33,7 +33,7 @@ class PlaceTypeTrajectory:
     place_type   : category of place
     visits       : chronologically ordered list of PlaceVisit
     trend        : per-dimension slope (positive = improving over time)
-    volatility   : mean std-dev across visits (emotional consistency)
+    volatility   : RMS of standard deviations across CHIME dimensions
     visit_count  : total number of visits
     """
     place_type: str

--- a/dreamsApp/core/extra/proximity_trajectory.py
+++ b/dreamsApp/core/extra/proximity_trajectory.py
@@ -2,7 +2,6 @@ import math
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Dict, List, Optional, Tuple
-import math
 
 
 CHIME_DIMENSIONS = ['Connectedness', 'Hope', 'Identity', 'Meaning', 'Empowerment']

--- a/dreamsApp/core/extra/proximity_trajectory.py
+++ b/dreamsApp/core/extra/proximity_trajectory.py
@@ -78,7 +78,7 @@ def build_place_trajectories(
         total_variance = 0.0
 
         for dim in CHIME_DIMENSIONS:
-            scores = [v.chime.get(dim, 0.0) for v in place_visits]
+            scores = [v.chime[dim] for v in place_visits]
             y_mean = sum(scores) / n
 
             if denominator == 0:

--- a/dreamsApp/core/extra/proximity_trajectory.py
+++ b/dreamsApp/core/extra/proximity_trajectory.py
@@ -1,25 +1,14 @@
-"""
-Proximity Trajectory Analysis
-
-Tracks how a person's emotional response to each place type evolves
-over time, and detects whether visits to recovery anchor places
-correlate with positive emotional shifts.
-
-This answers the core research question:
-"How do emotions attached to a class of places (e.g., any churches)
-evolve across a recovery journey?"
-
-Builds on:
-- place_emotion_signature.py: CHIME profiles per place type
-- temporal_narrative_graph.py: emotional episode structure
-"""
-
+import math
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
 
 
 CHIME_DIMENSIONS = ['Connectedness', 'Hope', 'Identity', 'Meaning', 'Empowerment']
+
+# Minimum slope magnitude to classify a trend as improving or declining.
+# Aligned with the default trend_threshold in detect_recovery_correlations.
+TREND_THRESHOLD = 0.01
 
 
 @dataclass
@@ -69,43 +58,39 @@ def build_place_trajectories(
         visits: List of PlaceVisit objects, any order
 
     Returns:
-        Dict of place_type -> PlaceTypeTrajectory, sorted by visit time
+        Dict of place_type -> PlaceTypeTrajectory, grouped in chronological
+        order of first visit per place type
     """
-    import math
+    # Pre-sort all visits by time so grouping preserves chronological order
+    sorted_visits = sorted(visits, key=lambda v: v.timestamp)
 
-    # Group by place type, sort by time
     grouped: Dict[str, List[PlaceVisit]] = {}
-    for v in visits:
+    for v in sorted_visits:
         grouped.setdefault(v.place_type, []).append(v)
-    for pt in grouped:
-        grouped[pt].sort(key=lambda v: v.timestamp)
 
     trajectories = {}
     for place_type, place_visits in grouped.items():
         n = len(place_visits)
 
-        # Compute per-dimension linear slope using least squares
-        # slope > 0 means dimension is increasing over visits (recovery signal)
-        trend = {}
+        # x_mean and denominator depend only on n, compute once per place type
+        x_mean = (n - 1) / 2.0
+        denominator = sum((i - x_mean) ** 2 for i in range(n))
+
+        trend: Dict[str, float] = {}
+        total_variance = 0.0
+
         for dim in CHIME_DIMENSIONS:
             scores = [v.chime.get(dim, 0.0) for v in place_visits]
-            if n < 2:
+            y_mean = sum(scores) / n
+
+            if denominator == 0:
                 trend[dim] = 0.0
             else:
-                # x = visit index (0, 1, 2, ...), y = score
-                x_mean = (n - 1) / 2.0
-                y_mean = sum(scores) / n
-                numerator = sum((i - x_mean) * (scores[i] - y_mean) for i in range(n))
-                denominator = sum((i - x_mean) ** 2 for i in range(n))
-                trend[dim] = numerator / denominator if denominator != 0 else 0.0
+                numerator = sum((i - x_mean) * (s - y_mean) for i, s in enumerate(scores))
+                trend[dim] = numerator / denominator
 
-        # Volatility: mean RMS std-dev across dimensions
-        total_variance = 0.0
-        for dim in CHIME_DIMENSIONS:
-            scores = [v.chime.get(dim, 0.0) for v in place_visits]
-            mean = sum(scores) / n
-            variance = sum((s - mean) ** 2 for s in scores) / n
-            total_variance += variance
+            total_variance += sum((s - y_mean) ** 2 for s in scores) / n
+
         volatility = math.sqrt(total_variance / len(CHIME_DIMENSIONS))
 
         trajectories[place_type] = PlaceTypeTrajectory(
@@ -123,7 +108,7 @@ def detect_recovery_correlations(
     trajectories: Dict[str, PlaceTypeTrajectory],
     recovery_dimensions: List[str] = None,
     min_visits: int = 2,
-    trend_threshold: float = 0.01,
+    trend_threshold: float = TREND_THRESHOLD,
 ) -> List[Tuple[str, str, float]]:
     """
     Detect place types where recovery-relevant CHIME dimensions are improving.
@@ -181,6 +166,7 @@ def summarize_trajectories(
     For each place type, returns:
     - visit_count
     - dominant_trend: dimension improving most
+    - trend_slope: slope of dominant dimension
     - trend_direction: 'improving', 'stable', or 'declining'
     - volatility
 
@@ -194,9 +180,9 @@ def summarize_trajectories(
     for place_type, traj in trajectories.items():
         best_dim, best_slope = get_dominant_trend_dimension(traj)
 
-        if best_slope > 0.02:
+        if best_slope > TREND_THRESHOLD:
             direction = 'improving'
-        elif best_slope < -0.02:
+        elif best_slope < -TREND_THRESHOLD:
             direction = 'declining'
         else:
             direction = 'stable'

--- a/dreamsApp/core/extra/proximity_trajectory.py
+++ b/dreamsApp/core/extra/proximity_trajectory.py
@@ -78,7 +78,7 @@ def build_place_trajectories(
         total_variance = 0.0
 
         for dim in CHIME_DIMENSIONS:
-            scores = [v.chime[dim] for v in place_visits]
+            scores = [v.chime.get(dim, 0.0) for v in place_visits]
             y_mean = sum(scores) / n
 
             if denominator == 0:

--- a/dreamsApp/core/extra/proximity_trajectory.py
+++ b/dreamsApp/core/extra/proximity_trajectory.py
@@ -1,0 +1,212 @@
+"""
+Proximity Trajectory Analysis
+
+Tracks how a person's emotional response to each place type evolves
+over time, and detects whether visits to recovery anchor places
+correlate with positive emotional shifts.
+
+This answers the core research question:
+"How do emotions attached to a class of places (e.g., any churches)
+evolve across a recovery journey?"
+
+Builds on:
+- place_emotion_signature.py: CHIME profiles per place type
+- temporal_narrative_graph.py: emotional episode structure
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict, List, Optional, Tuple
+
+
+CHIME_DIMENSIONS = ['Connectedness', 'Hope', 'Identity', 'Meaning', 'Empowerment']
+
+
+@dataclass
+class PlaceVisit:
+    """
+    A single visit to a place type with its emotional context.
+
+    place_type : category of place (e.g., 'church', 'park')
+    timestamp  : when the visit occurred
+    chime      : CHIME scores at time of visit
+    """
+    place_type: str
+    timestamp: datetime
+    chime: Dict[str, float]
+
+
+@dataclass
+class PlaceTypeTrajectory:
+    """
+    Emotional trajectory for a single place type over time.
+
+    place_type   : category of place
+    visits       : chronologically ordered list of PlaceVisit
+    trend        : per-dimension slope (positive = improving over time)
+    volatility   : mean std-dev across visits (emotional consistency)
+    visit_count  : total number of visits
+    """
+    place_type: str
+    visits: List[PlaceVisit]
+    trend: Dict[str, float]
+    volatility: float
+    visit_count: int
+
+
+def build_place_trajectories(
+    visits: List[PlaceVisit],
+) -> Dict[str, PlaceTypeTrajectory]:
+    """
+    Group visits by place type and compute emotional trajectory per type.
+
+    For each place type, computes:
+    - trend: linear slope of each CHIME dimension over visits
+      (positive = dimension is increasing across visits = improving)
+    - volatility: mean RMS std-dev across CHIME dimensions
+
+    Args:
+        visits: List of PlaceVisit objects, any order
+
+    Returns:
+        Dict of place_type -> PlaceTypeTrajectory, sorted by visit time
+    """
+    import math
+
+    # Group by place type, sort by time
+    grouped: Dict[str, List[PlaceVisit]] = {}
+    for v in visits:
+        grouped.setdefault(v.place_type, []).append(v)
+    for pt in grouped:
+        grouped[pt].sort(key=lambda v: v.timestamp)
+
+    trajectories = {}
+    for place_type, place_visits in grouped.items():
+        n = len(place_visits)
+
+        # Compute per-dimension linear slope using least squares
+        # slope > 0 means dimension is increasing over visits (recovery signal)
+        trend = {}
+        for dim in CHIME_DIMENSIONS:
+            scores = [v.chime.get(dim, 0.0) for v in place_visits]
+            if n < 2:
+                trend[dim] = 0.0
+            else:
+                # x = visit index (0, 1, 2, ...), y = score
+                x_mean = (n - 1) / 2.0
+                y_mean = sum(scores) / n
+                numerator = sum((i - x_mean) * (scores[i] - y_mean) for i in range(n))
+                denominator = sum((i - x_mean) ** 2 for i in range(n))
+                trend[dim] = numerator / denominator if denominator != 0 else 0.0
+
+        # Volatility: mean RMS std-dev across dimensions
+        total_variance = 0.0
+        for dim in CHIME_DIMENSIONS:
+            scores = [v.chime.get(dim, 0.0) for v in place_visits]
+            mean = sum(scores) / n
+            variance = sum((s - mean) ** 2 for s in scores) / n
+            total_variance += variance
+        volatility = math.sqrt(total_variance / len(CHIME_DIMENSIONS))
+
+        trajectories[place_type] = PlaceTypeTrajectory(
+            place_type=place_type,
+            visits=place_visits,
+            trend=trend,
+            volatility=volatility,
+            visit_count=n,
+        )
+
+    return trajectories
+
+
+def detect_recovery_correlations(
+    trajectories: Dict[str, PlaceTypeTrajectory],
+    recovery_dimensions: List[str] = None,
+    min_visits: int = 2,
+    trend_threshold: float = 0.01,
+) -> List[Tuple[str, str, float]]:
+    """
+    Detect place types where recovery-relevant CHIME dimensions are improving.
+
+    A positive trend in Hope or Connectedness across visits to a place type
+    suggests that place is contributing to recovery for this person.
+
+    Args:
+        trajectories: Output of build_place_trajectories()
+        recovery_dimensions: CHIME dimensions to check (default: Hope, Connectedness)
+        min_visits: Minimum visits required for reliable trend
+        trend_threshold: Minimum slope to count as meaningful improvement
+
+    Returns:
+        List of (place_type, dimension, slope) tuples where slope > threshold,
+        sorted by slope descending
+    """
+    if recovery_dimensions is None:
+        recovery_dimensions = ['Hope', 'Connectedness']
+
+    correlations = []
+    for place_type, traj in trajectories.items():
+        if traj.visit_count < min_visits:
+            continue
+        for dim in recovery_dimensions:
+            slope = traj.trend.get(dim, 0.0)
+            if slope > trend_threshold:
+                correlations.append((place_type, dim, slope))
+
+    return sorted(correlations, key=lambda x: x[2], reverse=True)
+
+
+def get_dominant_trend_dimension(traj: PlaceTypeTrajectory) -> Tuple[str, float]:
+    """
+    Return the CHIME dimension with the strongest positive trend for a place type.
+
+    Args:
+        traj: PlaceTypeTrajectory
+
+    Returns:
+        (dimension_name, slope) for the dimension improving most
+    """
+    if not traj.trend:
+        return ('None', 0.0)
+    best_dim = max(traj.trend, key=traj.trend.get)
+    return (best_dim, traj.trend[best_dim])
+
+
+def summarize_trajectories(
+    trajectories: Dict[str, PlaceTypeTrajectory],
+) -> Dict[str, Dict]:
+    """
+    Produce a human-readable summary of all place type trajectories.
+
+    For each place type, returns:
+    - visit_count
+    - dominant_trend: dimension improving most
+    - trend_direction: 'improving', 'stable', or 'declining'
+    - volatility
+
+    Args:
+        trajectories: Output of build_place_trajectories()
+
+    Returns:
+        Dict of place_type -> summary dict
+    """
+    summary = {}
+    for place_type, traj in trajectories.items():
+        best_dim, best_slope = get_dominant_trend_dimension(traj)
+
+        if best_slope > 0.02:
+            direction = 'improving'
+        elif best_slope < -0.02:
+            direction = 'declining'
+        else:
+            direction = 'stable'
+
+        summary[place_type] = {
+            'visit_count': traj.visit_count,
+            'dominant_trend': best_dim,
+            'trend_slope': round(best_slope, 4),
+            'trend_direction': direction,
+            'volatility': round(traj.volatility, 4),
+        }
+
+    return summary

--- a/tests/test_proximity_trajectory.py
+++ b/tests/test_proximity_trajectory.py
@@ -1,0 +1,253 @@
+import pytest
+from datetime import datetime, timedelta
+from dreamsApp.core.extra.proximity_trajectory import (
+    PlaceVisit,
+    PlaceTypeTrajectory,
+    build_place_trajectories,
+    detect_recovery_correlations,
+    get_dominant_trend_dimension,
+    summarize_trajectories,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_visit(place_type: str, day: int, hope: float, connectedness: float) -> PlaceVisit:
+    return PlaceVisit(
+        place_type=place_type,
+        timestamp=datetime(2024, 1, 1) + timedelta(days=day),
+        chime={
+            'Connectedness': connectedness,
+            'Hope': hope,
+            'Identity': 0.3,
+            'Meaning': 0.5,
+            'Empowerment': 0.4,
+        }
+    )
+
+
+@pytest.fixture
+def improving_church_visits():
+    # Hope increasing over 4 visits: 0.5 → 0.6 → 0.7 → 0.8
+    return [
+        make_visit('church', 0, hope=0.5, connectedness=0.6),
+        make_visit('church', 7, hope=0.6, connectedness=0.65),
+        make_visit('church', 14, hope=0.7, connectedness=0.7),
+        make_visit('church', 21, hope=0.8, connectedness=0.75),
+    ]
+
+
+@pytest.fixture
+def declining_hospital_visits():
+    # Hope decreasing over 3 visits: 0.4 → 0.3 → 0.2
+    return [
+        make_visit('hospital', 0, hope=0.4, connectedness=0.3),
+        make_visit('hospital', 5, hope=0.3, connectedness=0.25),
+        make_visit('hospital', 10, hope=0.2, connectedness=0.2),
+    ]
+
+
+@pytest.fixture
+def mixed_visits(improving_church_visits, declining_hospital_visits):
+    return improving_church_visits + declining_hospital_visits
+
+
+# ---------------------------------------------------------------------------
+# build_place_trajectories
+# ---------------------------------------------------------------------------
+
+class TestBuildPlaceTrajectories:
+
+    def test_returns_dict(self, mixed_visits):
+        result = build_place_trajectories(mixed_visits)
+        assert isinstance(result, dict)
+
+    def test_groups_by_place_type(self, mixed_visits):
+        result = build_place_trajectories(mixed_visits)
+        assert 'church' in result
+        assert 'hospital' in result
+
+    def test_visit_count(self, improving_church_visits):
+        result = build_place_trajectories(improving_church_visits)
+        assert result['church'].visit_count == 4
+
+    def test_visits_sorted_by_time(self, improving_church_visits):
+        import random
+        shuffled = improving_church_visits.copy()
+        random.shuffle(shuffled)
+        result = build_place_trajectories(shuffled)
+        times = [v.timestamp for v in result['church'].visits]
+        assert times == sorted(times)
+
+    def test_positive_trend_for_improving_visits(self, improving_church_visits):
+        result = build_place_trajectories(improving_church_visits)
+        assert result['church'].trend['Hope'] > 0
+
+    def test_negative_trend_for_declining_visits(self, declining_hospital_visits):
+        result = build_place_trajectories(declining_hospital_visits)
+        assert result['hospital'].trend['Hope'] < 0
+
+    def test_zero_trend_for_single_visit(self):
+        visits = [make_visit('park', 0, hope=0.7, connectedness=0.6)]
+        result = build_place_trajectories(visits)
+        assert result['park'].trend['Hope'] == 0.0
+
+    def test_volatility_non_negative(self, mixed_visits):
+        result = build_place_trajectories(mixed_visits)
+        for traj in result.values():
+            assert traj.volatility >= 0.0
+
+    def test_low_volatility_for_consistent_visits(self):
+        visits = [make_visit('church', i, hope=0.8, connectedness=0.7) for i in range(4)]
+        result = build_place_trajectories(visits)
+        assert result['church'].volatility == 0.0
+
+    def test_empty_visits_returns_empty(self):
+        result = build_place_trajectories([])
+        assert result == {}
+
+    def test_returns_place_type_trajectory(self, improving_church_visits):
+        result = build_place_trajectories(improving_church_visits)
+        assert isinstance(result['church'], PlaceTypeTrajectory)
+
+
+# ---------------------------------------------------------------------------
+# detect_recovery_correlations
+# ---------------------------------------------------------------------------
+
+class TestDetectRecoveryCorrelations:
+
+    def test_returns_list(self, mixed_visits):
+        trajs = build_place_trajectories(mixed_visits)
+        result = detect_recovery_correlations(trajs)
+        assert isinstance(result, list)
+
+    def test_improving_place_detected(self, improving_church_visits):
+        trajs = build_place_trajectories(improving_church_visits)
+        result = detect_recovery_correlations(trajs, trend_threshold=0.0)
+        place_types = [r[0] for r in result]
+        assert 'church' in place_types
+
+    def test_declining_place_not_detected(self, declining_hospital_visits):
+        trajs = build_place_trajectories(declining_hospital_visits)
+        result = detect_recovery_correlations(trajs, trend_threshold=0.0)
+        # hospital has negative trend, should not appear
+        place_types = [r[0] for r in result]
+        assert 'hospital' not in place_types
+
+    def test_sorted_by_slope_descending(self, mixed_visits):
+        trajs = build_place_trajectories(mixed_visits)
+        result = detect_recovery_correlations(trajs, trend_threshold=0.0)
+        slopes = [r[2] for r in result]
+        assert slopes == sorted(slopes, reverse=True)
+
+    def test_tuple_structure(self, improving_church_visits):
+        trajs = build_place_trajectories(improving_church_visits)
+        result = detect_recovery_correlations(trajs, trend_threshold=0.0)
+        for item in result:
+            place_type, dim, slope = item
+            assert isinstance(place_type, str)
+            assert isinstance(dim, str)
+            assert isinstance(slope, float)
+
+    def test_min_visits_filter(self):
+        visits = [make_visit('church', 0, hope=0.9, connectedness=0.8)]
+        trajs = build_place_trajectories(visits)
+        result = detect_recovery_correlations(trajs, min_visits=2, trend_threshold=0.0)
+        assert result == []
+
+    def test_custom_recovery_dimensions(self, improving_church_visits):
+        trajs = build_place_trajectories(improving_church_visits)
+        result = detect_recovery_correlations(
+            trajs, recovery_dimensions=['Meaning'], trend_threshold=0.0
+        )
+        for _, dim, _ in result:
+            assert dim == 'Meaning'
+
+    def test_empty_trajectories_returns_empty(self):
+        result = detect_recovery_correlations({})
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# get_dominant_trend_dimension
+# ---------------------------------------------------------------------------
+
+class TestGetDominantTrendDimension:
+
+    def test_returns_tuple(self, improving_church_visits):
+        trajs = build_place_trajectories(improving_church_visits)
+        result = get_dominant_trend_dimension(trajs['church'])
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+
+    def test_returns_highest_slope_dimension(self, improving_church_visits):
+        trajs = build_place_trajectories(improving_church_visits)
+        dim, slope = get_dominant_trend_dimension(trajs['church'])
+        assert isinstance(dim, str)
+        assert isinstance(slope, float)
+
+    def test_empty_trend_returns_none(self):
+        traj = PlaceTypeTrajectory(
+            place_type='empty', visits=[], trend={}, volatility=0.0, visit_count=0
+        )
+        dim, slope = get_dominant_trend_dimension(traj)
+        assert dim == 'None'
+        assert slope == 0.0
+
+
+# ---------------------------------------------------------------------------
+# summarize_trajectories
+# ---------------------------------------------------------------------------
+
+class TestSummarizeTrajectories:
+
+    def test_returns_dict(self, mixed_visits):
+        trajs = build_place_trajectories(mixed_visits)
+        result = summarize_trajectories(trajs)
+        assert isinstance(result, dict)
+
+    def test_all_place_types_present(self, mixed_visits):
+        trajs = build_place_trajectories(mixed_visits)
+        result = summarize_trajectories(trajs)
+        assert 'church' in result
+        assert 'hospital' in result
+
+    def test_summary_keys(self, improving_church_visits):
+        trajs = build_place_trajectories(improving_church_visits)
+        result = summarize_trajectories(trajs)
+        summary = result['church']
+        assert 'visit_count' in summary
+        assert 'dominant_trend' in summary
+        assert 'trend_slope' in summary
+        assert 'trend_direction' in summary
+        assert 'volatility' in summary
+
+    def test_improving_direction(self, improving_church_visits):
+        trajs = build_place_trajectories(improving_church_visits)
+        result = summarize_trajectories(trajs)
+        assert result['church']['trend_direction'] == 'improving'
+
+    def test_declining_direction(self, declining_hospital_visits):
+        trajs = build_place_trajectories(declining_hospital_visits)
+        result = summarize_trajectories(trajs)
+        # slope is negative but may be within stable threshold - check it's not improving
+        assert result['hospital']['trend_direction'] in ('declining', 'stable')
+        assert result['hospital']['trend_slope'] <= 0
+
+    def test_stable_direction(self):
+        visits = [make_visit('park', i, hope=0.7, connectedness=0.6) for i in range(3)]
+        trajs = build_place_trajectories(visits)
+        result = summarize_trajectories(trajs)
+        assert result['park']['trend_direction'] == 'stable'
+
+    def test_visit_count_correct(self, improving_church_visits):
+        trajs = build_place_trajectories(improving_church_visits)
+        result = summarize_trajectories(trajs)
+        assert result['church']['visit_count'] == 4
+
+    def test_empty_trajectories_returns_empty(self):
+        result = summarize_trajectories({})
+        assert result == {}


### PR DESCRIPTION
The place emotion signatures (PR #193) capture how a person emotionally experiences each place type on average. This PR adds the temporal layer on top — tracking whether those emotional responses are improving, stable, or declining across visits over time.

Given a user's visit history with CHIME scores per visit, compute a per-dimension linear trend for each place type. A positive slope on Hope at churches means the person is feeling progressively more hopeful there across visits — a potential recovery signal.

## Additons

`dreamsApp/core/extra/proximity_trajectory.py`

- `PlaceVisit` — dataclass holding place type, timestamp, and CHIME scores for a single visit
- `build_place_trajectories(visits)` — groups visits by place type, computes least-squares slope per CHIME dimension and visit-level volatility
- `detect_recovery_correlations(trajectories)` — returns place types where Hope/Connectedness are trending upward, sorted by slope
- `get_dominant_trend_dimension(traj)` — strongest improving dimension for a place type
- `summarize_trajectories(trajectories)` — per-place-type summary with trend direction (improving / stable / declining)

The input (CHIME scores + place type) already comes from the existing ingestion pipeline, so this fits as an analysis layer on top of existing data — same design pattern as `emotion_timeline.py` and `temporal_narrative_graph.py`.

## Example Output

Both charts below use simulated CHIME scores to demonstrate the analysis. In production, these scores would come from the CHIME model running on the user's actual photo captions per visit.

**Hope score across visits per place type** — solid lines are actual visit scores, dashed lines are the computed trend. Church shows a clear upward trend (recovery signal), hospital shows decline, park stays flat.

<img width="1335" height="733" alt="hope_trajectory" src="https://github.com/user-attachments/assets/fc13df0c-20bc-4fc0-99c0-96df6f0617ab" />


**Hope slope summary per place type** — positive bar = Hope is improving at that place type over time, negative = declining. This is what `detect_recovery_correlations()` surfaces.

<img width="1184" height="582" alt="trajectory_summary" src="https://github.com/user-attachments/assets/74ce0743-cc32-472c-8dba-05ccf484028b" />


## Tests

30 tests covering:
- `build_place_trajectories` correctly computes positive slope when Hope increases visit-over-visit, negative slope when it decreases, and zero slope for a single visit
- visits are sorted chronologically regardless of input order
- volatility is zero for identical visits, non-zero for inconsistent ones
- `detect_recovery_correlations` only returns place types with positive trend above threshold, respects min_visits filter, sorts by slope descending
- `summarize_trajectories` correctly labels improving/stable/declining based on slope magnitude

<img width="1738" height="898" alt="image" src="https://github.com/user-attachments/assets/fa04f0ae-a738-4cb8-830a-fd5871c3778a" />



@pradeeban one thing I'm unsure about — linear slope works fine for monotonic trends but might miss non-linear patterns (e.g., Hope dips mid-recovery then rises). Would a rolling window approach make more sense here, or is the linear trend sufficient for the current research stage?

